### PR TITLE
Add Gnuplot .dat files to gitginore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ App.config
 
 # Build artifacts
 */obj/
+
+# Gnuplot files
+*.dat


### PR DESCRIPTION
The tests in our repository generate `.dat` files, so we should add them to the gitignore.