### PR TITLE
This should fix the whole "Can't find Coroutines" problem

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -2,6 +2,10 @@ plugins {
     `java-library`
 }
 
+kotlin {
+    experimental.coroutines = org.jetbrains.kotlin.gradle.dsl.Coroutines.ENABLE
+}
+
 // TODO(svein): Shadow this, but do it such that we don't get one copy per subproject.
 //jar {
 //    from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }


### PR DESCRIPTION
This happens to myself, @Grissess, and @Caeleron and prevents us from running tests or compiling the code.

```
6:25:55 PM: Executing task 'build --scan'...

Parallel execution is an incubating feature.
> Task :core:compileKotlin FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':core:compileKotlin'.
> kotlin/coroutines/Continuation

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 5.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/4.10.3/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 0s
1 actionable task: 1 executed
```