### PR TITLE
Add move and swch operators, refactoring

### DIFF
--- a/core/src/main/kotlin/org/eln2/compute/asmComputer/AsmComputer.kt
+++ b/core/src/main/kotlin/org/eln2/compute/asmComputer/AsmComputer.kt
@@ -5,16 +5,13 @@ import org.eln2.compute.asmComputer.operators.*
 class AsmComputer {
 
 	// used to store integers
-	val intRegisters = mutableMapOf<String, Int>()
+	val intRegisters: MutableMap<String, IntRegister> = mutableMapOf<String, IntRegister>()
 
 	// used to store doubles
-	val doubleRegisters = mutableMapOf<String, Double>()
+	val doubleRegisters: MutableMap<String, DoubleRegister> = mutableMapOf<String, DoubleRegister>()
 
 	// used to store strings
-	val stringRegisters = mutableMapOf<String, StringBuffer>()
-
-	// combination of all registers (for searching)
-	val allRegisters: Map<String, Any> = intRegisters + doubleRegisters + stringRegisters
+	val stringRegisters: MutableMap<String, StringRegister> = mutableMapOf<String, StringRegister>()
 
 	// map of all possible operators by opcode
 	val operators: MutableMap<String, Operator>
@@ -24,22 +21,24 @@ class AsmComputer {
 	// Why we are in this state if it's errored.
 	var currStateReasoning = ""
 	// The code to run
-	var code = ""
+	var codeRegister = "cra"
 	// The code to run, split by newline
 	private var codeLines: List<String> = listOf()
 	// The pointer to the line of code to run from codeLines
 	var ptr = 0
 
 	init {
-		"abcdefgh".forEach { intRegisters["i$it"] = 0 }
-		"xyz".forEach { doubleRegisters["d$it"] = 0.0 }
-		"xyz".forEach { stringRegisters["s$it"] = StringBuffer(32) }
+		"abcdefgh".forEach { intRegisters["i$it"] = IntRegister() }
+		"xyz".forEach { doubleRegisters["d$it"] = DoubleRegister() }
+		"xyz".forEach { stringRegisters["s$it"] = StringRegister(1024) }
+		"ab".forEach{ stringRegisters["cr$it"] = StringRegister(4096) }
+
+		val operatorListing = listOf(NoOp(), AddI(), AddD(), SubI(), SubD(), Move(), CodeSwitch())
 		operators = mutableMapOf()
-		operators["noop"] = NoOp()
-		operators["addi"] = AddI()
-		operators["addd"] = AddD()
-		operators["subi"] = SubI()
-		operators["subd"] = SubD()
+
+		operatorListing.forEach {
+			operators[it.OPCODE] = it
+		}
 	}
 
 	/**
@@ -49,7 +48,14 @@ class AsmComputer {
 		if (this.currState == State.Errored) return
 		currState = State.Running
 		currStateReasoning = ""
-		codeLines = code.split("\n")
+		if (codeRegister !in listOf("cra", "crb")) {
+			currState = State.Errored
+			currStateReasoning = "Code Register must be cra or crb, found $codeRegister"
+		}
+		val cra = stringRegisters["cra"]?.contents
+		val crb = stringRegisters["crb"]?.contents
+		val codeRegisters = mapOf(Pair("cra", cra), Pair("crb", crb))
+			codeLines = (codeRegisters[codeRegister] ?: "").split("\n")
 		if (codeLines.size < ptr) {
 			currState = State.Stopped
 			currStateReasoning = "End of code"
@@ -73,58 +79,87 @@ class AsmComputer {
 	}
 }
 
-/**
- * States of our computer
- */
+// States of our computer
 enum class State {
-	/**
-	 * The computer is running
-	 */
+	// The computer is running
 	Running,
 
-	/**
-	 * The computer is stopped on an instruction (paused?)
-	 */
+	// The computer is stopped on an instruction (paused?)
 	Stopped,
 
-	/**
-	 * An invalid instruction was passed.
-	 */
+	// An invalid instruction was passed.
 	Errored,
 
-	/**
-	 * The computer is waiting for data
-	 */
+	// The computer is waiting for data
 	Data,
 }
 
-
-class StringBuffer(
-	/**
-	 * size: Maximum size of the buffer
-	 */
-	val size: Int) {
-
-	private var _contents: String = ""
-
-	/**
-	 * The actual data of the string is stored here. You can touch contents like a normal string, except that you can't
-	 * set the data to be longer than the buffer size.
-	 */
-	var contents
-		/**
-		 * Get the contents
-		 * @return Returns current contents
-		 */
-		get() = _contents
-		/**
-		 * Set the contents. Does nothing if the size is longer than size.
-		 * @param contents The new contents to set
-		 */
-		set(contents) {
-			// Only set the string if the size is smaller than the buffer we provide.
-			if (contents.length <= size) _contents = contents
+open class IntRegister(v: Int = 0) {
+	var _contents: Int = v
+	open var contents: Int
+		get() {
+			return _contents
 		}
+		set(value) {
+			_contents = value
+		}
+
+	override fun toString(): String {
+		return contents.toString()
+	}
+}
+class ReadOnlyIntRegister(v: Int = 0): IntRegister(v) {
+	override var contents: Int
+		get() {
+			return _contents
+		}
+		set(value) {
+			// do nothing
+		}
+}
+open class DoubleRegister(v: Double = 0.0) {
+	var _contents: Double = v
+	open var contents: Double
+		get() {
+			return _contents
+		}
+		set(value) {
+			_contents = value
+		}
+	override fun toString(): String {
+		return contents.toString()
+	}
+}
+class ReadOnlyDoubleRegister(v: Double = 0.0): DoubleRegister(v) {
+	override var contents: Double
+	get() {
+		return _contents
+	}
+	set(value) {
+		// do nothing
+	}
+}
+open class StringRegister(var size: Int, v: String = "") {
+	var _contents: String = v
+	open var contents: String
+	get() {
+		return _contents
+	}
+	set(value) {
+		if (value.length <= size) _contents = value
+	}
+	override fun toString(): String {
+		return contents
+	}
+}
+class ReadOnlyStringRegister(v: String = ""): StringRegister(0, v) {
+	override var contents: String
+	get() {
+		return _contents
+	}
+	set(value) {
+		// do nothing
+	}
 }
 
 /**
@@ -178,4 +213,11 @@ abstract class Operator {
 	 * @param asmComputer The computer instance we're running on.
 	 */
 	abstract fun run(opList: List<String>, asmComputer: AsmComputer)
+
+	fun findRegisterType(register: String, asmComputer: AsmComputer): Any? {
+		if (register in asmComputer.intRegisters) return IntRegister::class
+		if (register in asmComputer.doubleRegisters) return DoubleRegister::class
+		if (register in asmComputer.stringRegisters) return StringRegister::class
+		return null
+	}
 }

--- a/core/src/main/kotlin/org/eln2/compute/asmComputer/documentation.md
+++ b/core/src/main/kotlin/org/eln2/compute/asmComputer/documentation.md
@@ -1,0 +1,60 @@
+# AsmComputer
+
+## Registers
+
+Integer Registers:
+
+```
+ia
+ib
+ic
+id
+ie
+if
+ig
+ih
+```
+
+Double (FPU) Registers:
+
+```
+dx
+dy
+dz
+```
+
+String Registers:
+
+```
+sx
+sy
+sz
+cra: Code Register A
+crb: Code Register B
+si[0-9]: Serial in (read then clear to allow more input)
+so[0-9]: Serial out (write to have output)
+```
+
+## Operators
+
+All operators use the leftmost operand as the destination register.
+
+* `addi <register> (<register or literal> 1 .. N]`: Adds registers and literals to a register.
+* `addd <register> (<register or literal> 1 .. N]`: Adds registers and literals to a register.
+* `subi <register> <register or literal>`: Subtracts a register or literal from a register.
+* `subd <register> <register or literal>`: Subtracts a register or literal from a register.
+* `noop`: No-Op
+* `move <register> <register or literal>`: Copies the data from the second register or literal to the first register
+* `swch [literal]`: Switch to the opposite code register. Allows specifying a PTR to jump to.
+* `strp <register> <register> <literal> <literal>`: Allows copying a string from one string register to another with specific beginning and end points
+* `strl <register> <register>`: Copies the length of the string register into an integer register
+* `labl <literal>`: A label that `jump` and other code points can jump to (TODO: `swch`)
+* `jump <literal>`: A PTR or label to jump to.
+* `jpgt <register or literal> <register or literal> <literal>`: Jump if the left register is greater than the right one to the PTR or label specified.
+* `jplt <register or literal> <register or literal> <literal>`: Jump if the left register is less athan the right one to the PTR or label specified
+* `jpge <register or literal> <register or literal> <literal>`: Jump if the left register is greater than or equal to the right one to the PTR or label specified
+* `jple <register or literal> <register or literal> <literal>`: Jump if the left register is less than or equal to the right one to the PTR or label specified
+* `jpeq <register or literal> <register or literal> <literal>`: If the registers are equal, jump to the literal PTR or label specified.
+* `hasi <register> <register or literal>`: If the register exists, put a 1 in the dest register, otherwise put a 0.
+* `hasd <register> <register or literal>`: If the register exists, put a 1 in the dest register, otherwise put a 0.
+* `hass <register> <register or literal>`: If the register exists, put a 1 in the dest register, otherwise put a 0.

--- a/core/src/main/kotlin/org/eln2/compute/asmComputer/operators/Add.kt
+++ b/core/src/main/kotlin/org/eln2/compute/asmComputer/operators/Add.kt
@@ -15,10 +15,10 @@ open class AddI: Operator() {
 			asmComputer.currStateReasoning = "Nonexistent Register {}".format(opList[0])
 			return
 		}
-		var result = asmComputer.intRegisters[opList[0]]?: 0
+		var result = asmComputer.intRegisters[opList[0]]?.contents?: 0
 		opList.drop(1).map{
 			if (it in asmComputer.intRegisters) {
-				asmComputer.intRegisters[it]?: 0
+				asmComputer.intRegisters[it]?.contents?: 0
 			} else {
 				val v = it.toIntOrNull()
 				if (v == null) {
@@ -29,7 +29,7 @@ open class AddI: Operator() {
 				v
 			}
 		}.forEach { result += it }
-		asmComputer.intRegisters[opList[0]] = result
+		asmComputer.intRegisters[opList[0]]?.contents = result
 	}
 }
 
@@ -44,10 +44,10 @@ open class AddD: Operator() {
 			asmComputer.currStateReasoning = "Nonexistent Register {}".format(opList[0])
 			return
 		}
-		var result = asmComputer.doubleRegisters[opList[0]]?: 0.0
+		var result = asmComputer.doubleRegisters[opList[0]]?.contents?: 0.0
 		opList.drop(1).map{
 			if (it in asmComputer.doubleRegisters) {
-				asmComputer.doubleRegisters[it]?: 0.0
+				asmComputer.doubleRegisters[it]?.contents?: 0.0
 			} else {
 				val v = it.toDoubleOrNull()
 				if (v == null) {
@@ -58,6 +58,6 @@ open class AddD: Operator() {
 				v
 			}
 		}.forEach { result += it }
-		asmComputer.doubleRegisters[opList[0]] = result
+		asmComputer.doubleRegisters[opList[0]]?.contents = result
 	}
 }

--- a/core/src/main/kotlin/org/eln2/compute/asmComputer/operators/CodeSwitch.kt
+++ b/core/src/main/kotlin/org/eln2/compute/asmComputer/operators/CodeSwitch.kt
@@ -1,0 +1,25 @@
+package org.eln2.compute.asmComputer.operators
+
+import org.eln2.compute.asmComputer.AsmComputer
+import org.eln2.compute.asmComputer.Operator
+
+class CodeSwitch: Operator() {
+	override val OPCODE = "swch"
+	override val MIN_ARGS = 0
+	override val MAX_ARGS = 1
+	override val COST = 0.0
+	override fun run(opList: List<String>, asmComputer: AsmComputer) {
+		if (asmComputer.codeRegister == "cra") {
+			asmComputer.codeRegister = "crb"
+		}else{
+			asmComputer.codeRegister = "cra"
+		}
+		if (opList.size == 1) {
+			val newPtr = opList[0].toIntOrNull()
+			if (newPtr != null) {
+				// This is because the computer will step the pointer up by one after this instruction completes.
+				asmComputer.ptr = newPtr - 1
+			}
+		}
+	}
+}

--- a/core/src/main/kotlin/org/eln2/compute/asmComputer/operators/CopyStringPart.kt
+++ b/core/src/main/kotlin/org/eln2/compute/asmComputer/operators/CopyStringPart.kt
@@ -1,0 +1,34 @@
+package org.eln2.compute.asmComputer.operators
+
+import org.eln2.compute.asmComputer.*
+
+class CopyStringPart: Operator() {
+	override val OPCODE = "strp"
+	override val MIN_ARGS = 4
+	override val MAX_ARGS = 4
+	override val COST = 0.0
+	override fun run(opList: List<String>, asmComputer: AsmComputer) {
+		val toRegister = opList[0]
+		val fromRegister = opList[1]
+		val beginSlice = opList[2].toIntOrNull()
+		val endSlice = opList[3].toIntOrNull()
+
+		if (beginSlice == null || endSlice == null) {
+			asmComputer.currState = State.Errored
+			asmComputer.currStateReasoning = "String slices must be numbers, $beginSlice and/or $endSlice are not numbers"
+			return
+		}
+		if (
+			// determine that we have a writable destination and readable source
+			findRegisterType(toRegister, asmComputer) != StringRegister::class ||
+			findRegisterType(fromRegister, asmComputer) != StringRegister::class) {
+			asmComputer.currState = State.Errored
+			asmComputer.currStateReasoning = "$toRegister and/or $fromRegister are not string registers"
+			return
+		}
+
+		val data =  asmComputer.stringRegisters[fromRegister]?.contents?: ""
+		if (data.length < beginSlice || data.length < endSlice) return
+		asmComputer.stringRegisters[toRegister]?.contents = data.substring(beginSlice, endSlice)
+	}
+}

--- a/core/src/main/kotlin/org/eln2/compute/asmComputer/operators/Jump.kt
+++ b/core/src/main/kotlin/org/eln2/compute/asmComputer/operators/Jump.kt
@@ -1,0 +1,30 @@
+package org.eln2.compute.asmComputer.operators
+
+import org.eln2.compute.asmComputer.AsmComputer
+import org.eln2.compute.asmComputer.Operator
+import org.eln2.compute.asmComputer.State
+
+class Jump: Operator() {
+	override val OPCODE = "jump"
+	override val MIN_ARGS = 1
+	override val MAX_ARGS = 1
+	override val COST = 0.0
+	override fun run(opList: List<String>, asmComputer: AsmComputer) {
+		if (opList[0].toIntOrNull() != null) {
+			// go to a particular code pointer location
+			asmComputer.ptr = (opList[0].toIntOrNull()?: 0) - 2
+		}else{
+			// go to a label
+			val labelNameArray = opList[0].split("\"") // labels are quoted string literals.
+			if (labelNameArray.size != 3) {
+				asmComputer.currState = State.Errored
+				asmComputer.currStateReasoning = "Label ${opList[0]} is invalid"
+			}
+			val labelName = labelNameArray[1]
+			val codeLines = asmComputer.stringRegisters[asmComputer.codeRegister]?.contents?.split("\n") ?: return
+			var labelLocation = codeLines.indexOf("labl \"$labelName\"")
+			if (labelLocation == -1) return // do nothing
+			asmComputer.ptr = labelLocation - 1 // to the line before the label, since the ptr will be +1'd after op.
+		}
+	}
+}

--- a/core/src/main/kotlin/org/eln2/compute/asmComputer/operators/Label.kt
+++ b/core/src/main/kotlin/org/eln2/compute/asmComputer/operators/Label.kt
@@ -1,0 +1,13 @@
+package org.eln2.compute.asmComputer.operators
+
+import org.eln2.compute.asmComputer.AsmComputer
+import org.eln2.compute.asmComputer.Operator
+
+class Label: Operator() {
+	override val OPCODE = "labl"
+	override val MIN_ARGS = 1
+	override val MAX_ARGS = 1
+	override val COST = 0.0
+	// It literally does nothing.
+	override fun run(opList: List<String>, asmComputer: AsmComputer) {}
+}

--- a/core/src/main/kotlin/org/eln2/compute/asmComputer/operators/Move.kt
+++ b/core/src/main/kotlin/org/eln2/compute/asmComputer/operators/Move.kt
@@ -1,0 +1,125 @@
+package org.eln2.compute.asmComputer.operators
+
+import org.eln2.compute.asmComputer.*
+
+open class Move: Operator() {
+	override val OPCODE = "move"
+	override val MIN_ARGS = 2
+	override val MAX_ARGS = 2
+	override val COST = 0.0
+	override fun run(opList: List<String>, asmComputer: AsmComputer) {
+		if (opList.size != 2) {
+			asmComputer.currState = State.Errored
+			asmComputer.currStateReasoning = "Invalid move command: $opList"
+			return
+		}
+
+		//println("Trying move: ${opList}")
+
+		val outputClass = findRegisterType(opList[0], asmComputer)
+		val inputClass = findRegisterType(opList[1], asmComputer)
+
+		if (outputClass == null) {
+			asmComputer.currState = State.Errored
+			asmComputer.currStateReasoning = "First argument ${opList[0]} not a register"
+			return
+		}
+
+		if (inputClass == null) {
+			when(outputClass) {
+				IntRegister::class, ReadOnlyIntRegister::class -> {
+					asmComputer.intRegisters[opList[0]]?.contents = opList[1].toIntOrNull()?: 0
+					return
+				}
+				DoubleRegister::class, ReadOnlyDoubleRegister::class -> {
+					asmComputer.doubleRegisters[opList[0]]!!.contents = opList[1].toDoubleOrNull()?: 0.0
+					return
+				}
+				StringRegister::class, ReadOnlyStringRegister::class -> {
+					val spl = opList[1].split("\"")
+					if (spl.size != 3) return
+					// The big string replace allows \ to be used to escape a space. The string must be in double quotes.
+					asmComputer.stringRegisters[opList[0]]?.contents = spl[1].replace("\\"," ").replace("\\ \\", "\\")
+					return
+				}
+				else -> {
+					asmComputer.currState = State.Errored
+					asmComputer.currStateReasoning = "Not sure what type this register is: ${opList[0]}"
+					return
+				}
+			}
+		}
+
+
+		when (outputClass) {
+			IntRegister::class, ReadOnlyIntRegister::class -> {
+				when(inputClass) {
+					IntRegister::class, ReadOnlyIntRegister::class -> {
+						asmComputer.intRegisters[opList[0]]?.contents = asmComputer.intRegisters[opList[1]]?.contents?: 0
+						return
+					}
+					DoubleRegister::class, ReadOnlyDoubleRegister::class -> {
+						asmComputer.intRegisters[opList[0]]?.contents = (asmComputer.doubleRegisters[opList[1]]?.contents?: 0.0).toInt()
+						return
+					}
+					StringRegister::class, ReadOnlyStringRegister::class -> {
+						asmComputer.intRegisters[opList[0]]?.contents = (asmComputer.stringRegisters[opList[1]]?.contents?: "").toIntOrNull()?: 0
+						return
+					}
+					else -> {
+						asmComputer.currState = State.Errored
+						asmComputer.currStateReasoning = "Not sure what type this register is: ${opList[0]}"
+						return
+					}
+				}
+			}
+			DoubleRegister::class, ReadOnlyDoubleRegister::class -> {
+				when(inputClass) {
+					IntRegister::class, ReadOnlyIntRegister::class -> {
+						asmComputer.doubleRegisters[opList[0]]?.contents = (asmComputer.intRegisters[opList[1]]?.contents?: 0).toDouble()
+						return
+					}
+					DoubleRegister::class, ReadOnlyDoubleRegister::class -> {
+						asmComputer.doubleRegisters[opList[0]]?.contents = (asmComputer.doubleRegisters[opList[1]]?.contents?: 0.0)
+						return
+					}
+					StringRegister::class, ReadOnlyStringRegister::class -> {
+						asmComputer.doubleRegisters[opList[0]]?.contents = (asmComputer.stringRegisters[opList[1]]?.contents?: "").toDoubleOrNull()?: 0.0
+						return
+					}
+					else -> {
+						asmComputer.currState = State.Errored
+						asmComputer.currStateReasoning = "Not sure what type this register is: ${opList[0]}"
+						return
+					}
+				}
+			}
+			StringRegister::class, ReadOnlyStringRegister::class -> {
+				when(inputClass) {
+					IntRegister::class, ReadOnlyIntRegister::class -> {
+						asmComputer.stringRegisters[opList[0]]?.contents = (asmComputer.intRegisters[opList[1]]?.contents?: 0).toString()
+						return
+					}
+					DoubleRegister::class, ReadOnlyDoubleRegister::class -> {
+						asmComputer.stringRegisters[opList[0]]?.contents = (asmComputer.doubleRegisters[opList[1]]?.contents?: 0.0).toString()
+						return
+					}
+					StringRegister::class, ReadOnlyStringRegister::class -> {
+						asmComputer.stringRegisters[opList[0]]?.contents = (asmComputer.stringRegisters[opList[1]]?.contents?: "")
+						return
+					}
+					else -> {
+						asmComputer.currState = State.Errored
+						asmComputer.currStateReasoning = "Not sure what type this register is: ${opList[0]}"
+						return
+					}
+				}
+			}
+			else -> {
+				asmComputer.currState = State.Errored
+				asmComputer.currStateReasoning = "Not sure what type this register is: ${opList[0]}"
+				return
+			}
+		}
+	}
+}

--- a/core/src/main/kotlin/org/eln2/compute/asmComputer/operators/StringLength.kt
+++ b/core/src/main/kotlin/org/eln2/compute/asmComputer/operators/StringLength.kt
@@ -1,0 +1,22 @@
+package org.eln2.compute.asmComputer.operators
+
+import org.eln2.compute.asmComputer.*
+
+class StringLength: Operator() {
+	override val OPCODE = "strl"
+	override val MIN_ARGS = 2
+	override val MAX_ARGS = 2
+	override val COST = 0.0
+	override fun run(opList: List<String>, asmComputer: AsmComputer) {
+		val intLengthRegister = opList[0]
+		val stringRegister = opList[1]
+		if (
+			findRegisterType(intLengthRegister, asmComputer) != IntRegister::class ||
+			findRegisterType(stringRegister, asmComputer) != StringRegister::class) {
+			asmComputer.currState = State.Errored
+			asmComputer.currStateReasoning = "$intLengthRegister is not a writable int register, and/or $stringRegister is not a readable string register"
+			return
+		}
+		asmComputer.intRegisters[intLengthRegister]?.contents = asmComputer.stringRegisters[stringRegister]?.contents?.length?: 0
+	}
+}

--- a/core/src/main/kotlin/org/eln2/compute/asmComputer/operators/Subtract.kt
+++ b/core/src/main/kotlin/org/eln2/compute/asmComputer/operators/Subtract.kt
@@ -15,10 +15,10 @@ open class SubI: Operator() {
 			asmComputer.currStateReasoning = "Nonexistent Register {}".format(opList[0])
 			return
 		}
-		var result = asmComputer.intRegisters[opList[0]]?: 0
+		var result = asmComputer.intRegisters[opList[0]]?.contents?: 0
 		opList.drop(1).map{
 			if (it in asmComputer.intRegisters) {
-				asmComputer.intRegisters[it]?: 0
+				asmComputer.intRegisters[it]?.contents?: 0
 			} else {
 				val v = it.toIntOrNull()
 				if (v == null) {
@@ -29,7 +29,7 @@ open class SubI: Operator() {
 				v
 			}
 		}.forEach { result -= it }
-		asmComputer.intRegisters[opList[0]] = result
+		asmComputer.intRegisters[opList[0]]?.contents = result
 	}
 }
 
@@ -44,10 +44,10 @@ open class SubD: Operator() {
 			asmComputer.currStateReasoning = "Nonexistent Register {}".format(opList[0])
 			return
 		}
-		var result = asmComputer.doubleRegisters[opList[0]]?: 0.0
+		var result = asmComputer.doubleRegisters[opList[0]]?.contents?: 0.0
 		opList.drop(1).map{
 			if (it in asmComputer.doubleRegisters) {
-				asmComputer.doubleRegisters[it]?: 0.0
+				asmComputer.doubleRegisters[it]?.contents?: 0.0
 			} else {
 				val v = it.toDoubleOrNull()
 				if (v == null) {
@@ -58,6 +58,6 @@ open class SubD: Operator() {
 				v
 			}
 		}.forEach { result -= it }
-		asmComputer.doubleRegisters[opList[0]] = result
+		asmComputer.doubleRegisters[opList[0]]?.contents = result
 	}
 }

--- a/core/src/test/kotlin/org/eln2/compute/asmComputer/AsmComputerTest.kt
+++ b/core/src/test/kotlin/org/eln2/compute/asmComputer/AsmComputerTest.kt
@@ -8,44 +8,85 @@ class AsmComputerTest {
 	@Test
 	fun testAddI() {
 		val computer = AsmComputer()
-		computer.code = "addi ia 2\naddi ia 4\naddi ia ia ia"
+		computer.stringRegisters["cra"]?.contents = "addi ia 2\naddi ia 4\naddi ia ia ia"
 		computer.step()
 		computer.step()
 		computer.step()
-		Assertions.assertEquals(true, computer.intRegisters["ia"] == 0 + 2 + 4 + 6 + 6)
+		Assertions.assertEquals(true, computer.intRegisters["ia"]?.contents == 0 + 2 + 4 + 6 + 6)
 	}
 
 	@Test
 	fun testSubI() {
 		val computer = AsmComputer()
-		computer.code = "subi ib 2\nsubi ib 2"
+		computer.stringRegisters["cra"]?.contents = "subi ib 2\nsubi ib 2"
 		computer.step()
 		computer.step()
-		Assertions.assertEquals(true, computer.intRegisters["ib"] == 0 - 2 - 2)
+		Assertions.assertEquals(true, computer.intRegisters["ib"]?.contents == 0 - 2 - 2)
 	}
 
 	@Test
 	fun testAddD() {
 		val computer = AsmComputer()
-		computer.code = "addd dx 3.14\naddd dx dx"
+		computer.stringRegisters["cra"]?.contents = "addd dx 3.14\naddd dx dx"
 		computer.step()
 		computer.step()
 		val testTopRange = (0.0 + 3.14 + 3.14) + 0.01
 		val testBottomRange = (0.0 + 3.14 + 3.14) - 0.01
-		val result = computer.doubleRegisters["dx"]?: 0.0
+		val result = computer.doubleRegisters["dx"]?.contents?: 0.0
 		Assertions.assertEquals(true, (result < testTopRange) && (result > testBottomRange))
 	}
 
 	@Test
 	fun testSubD() {
 		val computer = AsmComputer()
-		computer.ptr = 0
-		computer.code = "subd dx 3.14\nsubd dx 5.5"
+		computer.stringRegisters["cra"]?.contents = "subd dx 3.14\nsubd dx 5.5"
 		computer.step()
 		computer.step()
 		val testTopRange = (0.0 - 3.14 - 5.5) + 0.01
 		val testBottomRange = (0.0 - 3.14 - 5.5) - 0.01
-		val result = computer.doubleRegisters["dx"]?: 0.0
+		val result = computer.doubleRegisters["dx"]?.contents?: 0.0
 		Assertions.assertEquals(true, (result < testTopRange) && (result > testBottomRange))
+	}
+
+	@Test
+	fun testMoveInt() {
+		val computer = AsmComputer()
+		computer.stringRegisters["cra"]?.contents = "move ia 1\nmove ib ia"
+		computer.step()
+		computer.step()
+		Assertions.assertEquals(true, computer.intRegisters["ib"]?.contents == 1)
+	}
+
+	@Test
+	fun testMoveDouble() {
+		val computer = AsmComputer()
+		computer.stringRegisters["cra"]?.contents = "addd dx 5.0\nmove dx 1.0\nmove dy dx"
+		computer.step()
+		println(computer.doubleRegisters)
+		computer.step()
+		println(computer.doubleRegisters)
+		computer.step()
+		println(computer.doubleRegisters)
+		Assertions.assertEquals(true, computer.doubleRegisters["dy"]?.contents == 1.0)
+	}
+
+	@Test
+	fun testMoveString() {
+		val computer = AsmComputer()
+		computer.stringRegisters["cra"]?.contents = "move sx \"Hello\"\nmove sy sx"
+		computer.step()
+		computer.step()
+		Assertions.assertEquals(true, computer.stringRegisters["sy"]?.contents == "Hello")
+	}
+
+	@Test
+	fun codeFromVariable() {
+		val computer = AsmComputer()
+		computer.stringRegisters["cra"]?.contents = "move crb sy\nswch 0"
+		computer.stringRegisters["sy"]?.contents = "move ia 1"
+		computer.step()
+		computer.step()
+		computer.step()
+		Assertions.assertEquals(true, computer.intRegisters["ia"]?.contents == 1)
 	}
 }

--- a/core/src/test/kotlin/org/eln2/compute/asmComputer/AsmComputerTest.kt
+++ b/core/src/test/kotlin/org/eln2/compute/asmComputer/AsmComputerTest.kt
@@ -62,11 +62,8 @@ class AsmComputerTest {
 		val computer = AsmComputer()
 		computer.stringRegisters["cra"]?.contents = "addd dx 5.0\nmove dx 1.0\nmove dy dx"
 		computer.step()
-		println(computer.doubleRegisters)
 		computer.step()
-		println(computer.doubleRegisters)
 		computer.step()
-		println(computer.doubleRegisters)
 		Assertions.assertEquals(true, computer.doubleRegisters["dy"]?.contents == 1.0)
 	}
 
@@ -84,6 +81,48 @@ class AsmComputerTest {
 		val computer = AsmComputer()
 		computer.stringRegisters["cra"]?.contents = "move crb sy\nswch 0"
 		computer.stringRegisters["sy"]?.contents = "move ia 1"
+		computer.step()
+		computer.step()
+		computer.step()
+		Assertions.assertEquals(true, computer.intRegisters["ia"]?.contents == 1)
+	}
+
+	@Test
+	fun copyStringPart() {
+		val computer = AsmComputer()
+		computer.stringRegisters["cra"]?.contents = "strp sy sx 6 11"
+		computer.stringRegisters["sx"]?.contents = "Hello World"
+		computer.step()
+		println(computer.stringRegisters)
+		println(computer.stringRegisters["sy"]?.contents)
+		Assertions.assertEquals(true, computer.stringRegisters["sy"]?.contents == "World")
+	}
+
+	@Test
+	fun stringLength() {
+		val computer = AsmComputer()
+		computer.stringRegisters["cra"]?.contents = "strl ia sx"
+		computer.stringRegisters["sx"]?.contents = "Hello!"
+		computer.step()
+		Assertions.assertEquals(true, computer.intRegisters["ia"]?.contents == 6)
+	}
+
+	@Test
+	fun labelJump() {
+		val computer = AsmComputer()
+		computer.stringRegisters["cra"]?.contents = "noop\nnoop\nlabl \"doot\"\naddi ia 1\nnoop\njump \"doot\"\nnoop"
+		computer.ptr = 5
+		computer.step()
+		computer.step()
+		computer.step()
+		Assertions.assertEquals(true, computer.intRegisters["ia"]?.contents == 1)
+	}
+
+	@Test
+	fun indexJump() {
+		val computer = AsmComputer()
+		computer.stringRegisters["cra"]?.contents = "noop\nnoop\nlabl \"doot\"\naddi ia 1\naddi ia 30\njump 3\nnoop"
+		computer.ptr = 5
 		computer.step()
 		computer.step()
 		computer.step()


### PR DESCRIPTION
I added the move and swch operators.

move takes a literal or a register and copies it into another register
swch optionally takes a pointer value, and switches from cra to crb

Added two new code registers - the computer can switch from one to the
other while running and this allows the dynamic loading of more code
from wherever you would like. It also means that the code initially
loaded into a computer can be flexible. In the future, someone may want
to make it so that these registers can be optionally set to read-only
registers.

I also added read-only versions of all registers that currently exist.