### PR TITLE
Add a Falstad importer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ options.txt
 */classes
 */obj/
 
+# Graphviz Dot output files
+*.dot
+
 # IntelliJ
 .idea
 *.iml

--- a/core/src/main/kotlin/org/eln2/debug/DebugPrint.kt
+++ b/core/src/main/kotlin/org/eln2/debug/DebugPrint.kt
@@ -8,7 +8,18 @@ val DEBUG_FLAGS = listOf("mods.eln.debug", "eln2.core.debug", "eln2.all.debug")
 /**
  * Debug: If this is true, debug prints will print out
  */
-var DEBUG = System.getenv().filterKeys { key -> DEBUG_FLAGS.any { it.toLowerCase() == key.toLowerCase() } }.isNotEmpty()
+var DEBUG =
+	(
+		System.getenv().filterKeys {
+			key -> DEBUG_FLAGS.any {
+				it.toLowerCase().replace('.', '_') == key.toLowerCase()
+			}
+		}
+		+
+		System.getProperties().filterKeys {
+			key -> DEBUG_FLAGS.any { it == key }
+		}
+	).isNotEmpty()
 
 /**
  * dprintln: Print's empty newline if DEBUG = True

--- a/core/src/main/kotlin/org/eln2/load/Falstad.kt
+++ b/core/src/main/kotlin/org/eln2/load/Falstad.kt
@@ -76,6 +76,7 @@ interface ComponentConstructor {
 
 class InterpretGlobals: ComponentConstructor {
 	override fun construct(ccd: CCData) {
+		ccd.falstad.nominalTimestep = ccd.line.getDouble(2)
 		ccd.pins = 0
 	}
 }
@@ -197,11 +198,12 @@ class Falstad(val source: String) {
 	fun addOutput(pr: PinRef) = outputs.add(pr)
 	val outputNodes get() = outputs.map { it.node }
 
+	var nominalTimestep = 0.05
 	// Set to false directly by various constructors that introduce explicit grounds
 	var floating = true
 
 	val circuit = Circuit()
-	
+
 	init {
 		FalstadLine.intoLines(source).forEach {
 			ComponentConstructor.getForLine(it)
@@ -305,8 +307,9 @@ w 256 176 304 176 0
 """
 
 			val f = Falstad(falstad)
-			f.circuit.step(0.05)
 			println("$f:\n${f.source}\n${f.roots}\n${f.refs}\n${f.grounds}\n\n${f.circuit}")
+
+			f.circuit.step(f.nominalTimestep)
 
 			f.circuit.components.forEach {
 				println("$it:")

--- a/core/src/main/kotlin/org/eln2/load/Falstad.kt
+++ b/core/src/main/kotlin/org/eln2/load/Falstad.kt
@@ -1,0 +1,333 @@
+package org.eln2.load
+
+import org.eln2.debug.DEBUG
+import org.eln2.debug.dprintln
+import org.eln2.sim.electrical.mna.Circuit
+import org.eln2.sim.electrical.mna.component.*
+import org.eln2.space.Set
+import org.eln2.space.Vec2i
+import java.io.FileOutputStream
+import kotlin.math.absoluteValue
+
+val SPACES = Regex(" +")
+
+data class PinRef(val component: Component, val pinidx: Int) {
+	val node get() = component.node(pinidx)
+}
+data class PinPos(val pos: Vec2i)
+
+class FalstadLine(val params: Array<String>) {
+	companion object {
+		fun fromLine(s: String): FalstadLine? {
+			val trimmed = s.trim()
+			return if(trimmed.isEmpty())
+				null
+			else
+				FalstadLine(trimmed.split(SPACES).map { it.trim() }.toTypedArray())
+		}
+		fun intoLines(src: String) = src.lines().mapNotNull { fromLine(it) }
+	}
+
+	operator fun get(i: Int) = params[i]
+	
+	fun getInt(i: Int) = get(i).toInt()
+	fun getDouble(i: Int) = get(i).toDouble()
+}
+
+data class CCData(val falstad: Falstad, val line: FalstadLine) {
+	val circuit get() = falstad.circuit
+
+	// Sets the conceptual number of nodes of the component--not the actual number of positions in the line!
+	var pins: Int = 2
+
+	val pinPositions get() = (0 until 2).map { PinPos(Vec2i(line.getInt(1 + 2*it), line.getInt(2 + 2*it))) }
+
+	// Only safe to use these if pins >= 2
+	val pos: PinPos get() = pinPositions[0]
+	val neg: PinPos get() = pinPositions[1]
+	
+	val flags: Int get() = line.getInt(5)
+	val type: String get() = line[0]
+
+	val data get() = line.params.drop(6)
+}
+
+data class PosSet(val pos: PinPos): Set()
+
+interface ComponentConstructor {
+	companion object {
+		val TYPE_CONSTRUCTORS: Map<String, ComponentConstructor> = mapOf(
+			"$" to InterpretGlobals(),
+			"O" to OutputProbe(),
+			"w" to WireConstructor(),
+			"g" to GroundConstructor(),
+			"r" to ResistorConstructor(),
+			"l" to InductorConstructor(),
+			"c" to CapacitorConstructor(),
+			"v" to VoltageSourceConstructor(),
+			"172" to VoltageRailConstructor(),
+			"i" to CurrentSourceConstructor()
+		)
+		
+		fun getForLine(fl: FalstadLine) = TYPE_CONSTRUCTORS[fl[0]] ?: error("unrecognized type: ${fl[0]}")
+	}
+	fun construct(ccd: CCData)
+}
+
+class InterpretGlobals: ComponentConstructor {
+	override fun construct(ccd: CCData) {
+		ccd.pins = 0
+	}
+}
+
+class OutputProbe: ComponentConstructor {
+	companion object {
+		val HIGH_IMPEDANCE = Double.POSITIVE_INFINITY
+	}
+
+	override fun construct(ccd: CCData) {
+		val r = Resistor()
+		r.resistance = HIGH_IMPEDANCE
+		ccd.circuit.add(r)
+		r.connect(1, ccd.circuit.ground)
+
+		val pp = (ccd.falstad.getPin(ccd.pos).representative as PosSet)
+		val pr = PinRef(r, 0)
+		ccd.falstad.addPinRef(pp, pr)
+		ccd.falstad.addOutput(pr)
+
+		ccd.pins = 1
+	}
+}
+
+class WireConstructor: ComponentConstructor {
+	override fun construct(ccd: CCData) {
+		ccd.falstad.getPin(ccd.pos)
+			.unite(ccd.falstad.getPin(ccd.neg))
+	}
+}
+
+class GroundConstructor: ComponentConstructor {
+	override fun construct(ccd: CCData) {
+		ccd.pins = 1
+		ccd.falstad.addGround(
+			ccd.falstad.getPin(ccd.pinPositions[0])
+		)
+		ccd.falstad.floating = false
+	}
+}
+
+abstract class PoleConstructor: ComponentConstructor {
+	abstract fun component(ccd: CCData): Component
+	abstract fun configure(ccd: CCData, cmp: Component)
+
+	override fun construct(ccd: CCData) {
+		val c = component(ccd)
+		ccd.circuit.add(c)
+		configure(ccd, c)
+		ccd.pinPositions.withIndex().forEach {
+			val pp = (ccd.falstad.getPin(it.value).representative as PosSet)
+			ccd.falstad.addPinRef(pp, PinRef(c, it.index))
+		}
+	}
+}
+
+class ResistorConstructor: PoleConstructor() {
+	override fun component(ccd: CCData) = Resistor()
+	override fun configure(ccd: CCData, cmp: Component) {
+		(cmp as Resistor).resistance = ccd.data[0].toDouble()
+	}
+}
+
+class CapacitorConstructor: PoleConstructor() {
+	override fun component(ccd: CCData) = Capacitor()
+	override fun configure(ccd: CCData, cmp: Component) {
+		val c = (cmp as Capacitor)
+		c.c = ccd.data[0].toDouble()
+		c.lastI = ccd.data[1].toDouble()
+	}
+}
+
+class InductorConstructor: PoleConstructor() {
+	override fun component(ccd: CCData) = Inductor()
+	override fun configure(ccd: CCData, cmp: Component) {
+		val l = (cmp as Inductor)
+		l.h = ccd.data[0].toDouble()
+		l.lastI = ccd.data[1].toDouble()
+	}
+}
+
+class VoltageSourceConstructor: PoleConstructor() {
+	override fun component(ccd: CCData) = VoltageSource()
+	override fun configure(ccd: CCData, cmp: Component) {
+		(cmp as VoltageSource).potential = ccd.data[2].toDouble()
+	}
+}
+
+class VoltageRailConstructor: PoleConstructor() {
+	override fun component(ccd: CCData) = VoltageSource()
+	override fun configure(ccd: CCData, cmp: Component) {
+		val v = (cmp as VoltageSource)
+		v.potential = ccd.data[2].toDouble() + ccd.data[3].toDouble()
+		v.connect(1, ccd.circuit.ground)  // nidx 1 should be neg
+		ccd.pins = 1  // After the above--there are two pins, but the second is dropped
+		ccd.falstad.floating = false
+	}
+}
+
+class CurrentSourceConstructor: PoleConstructor() {
+	override fun component(ccd: CCData) = CurrentSource()
+	override fun configure(ccd: CCData, cmp: Component) {
+		(cmp as CurrentSource).current = ccd.data[0].toDouble()
+	}
+}
+
+class Falstad(val source: String) {
+	val roots: MutableMap<PinPos, PosSet> = mutableMapOf()
+	fun getPin(p: PinPos) = roots.getOrPut(p, { PosSet(p) })
+
+	val refs: MutableMap<PosSet, MutableSet<PinRef>> = mutableMapOf()
+	fun getPinRefs(p: PosSet) = refs.getOrPut(p, { mutableSetOf() })
+	fun addPinRef(p: PosSet, pr: PinRef) = getPinRefs(p).add(pr)
+	
+	val grounds: MutableSet<PosSet> = mutableSetOf()
+	fun addGround(p: PosSet) = grounds.add(p)
+	
+	val outputs: MutableSet<PinRef> = mutableSetOf()
+	fun addOutput(pr: PinRef) = outputs.add(pr)
+	val outputNodes get() = outputs.map { it.node }
+
+	// Set to false directly by various constructors that introduce explicit grounds
+	var floating = true
+
+	val circuit = Circuit()
+	
+	init {
+		FalstadLine.intoLines(source).forEach {
+			ComponentConstructor.getForLine(it)
+				.construct(CCData(this, it))
+		}
+
+		if(DEBUG) {
+			val repmap: MutableMap<PosSet, MutableSet<PosSet>> = mutableMapOf()
+			roots.values.forEach {
+				dprintln("F.<init>: r ${it} => ${it.representative}")
+				repmap.getOrPut(it.representative as PosSet, { mutableSetOf() }).add(it)
+			}
+
+			repmap.entries.forEach {
+				dprintln("F.<init>: R ${it.key}:")
+				it.value.forEach {
+					dprintln(" - $it")
+				}
+			}
+		}
+
+		val mergedRefs: MutableMap<PosSet, MutableSet<PinRef>> = mutableMapOf()
+		roots.values.forEach {
+			val set = refs[it]
+			if(set != null) {
+				mergedRefs.getOrPut(it.representative as PosSet, { mutableSetOf() }).addAll(set)
+			}
+		}
+
+		if(DEBUG) mergedRefs.entries.forEach {
+			dprintln("F.<init>: mR ${it.key} => ${it.value}")
+		}
+
+		mergedRefs.values.forEach {
+			val ordered = it.toList()  // Just need some ordering, any will do
+			(0 until ordered.size - 1).forEach {
+				ordered[it].component.connect(
+					ordered[it].pinidx,
+					ordered[it+1].component,
+					ordered[it+1].pinidx
+				)
+			}
+		}
+
+		grounds.forEach {
+			val set = refs[it.representative]
+			if(set != null && set.size > 0) {
+				// Only need to connect 1; the disjoint PosSets are merged right now
+				val pr = set.iterator().next()
+				pr.component.connect(pr.pinidx, circuit.ground)
+			}
+		}
+
+		if(floating) {
+			// This isn't expected to be the hotpath, so spend some extra time
+			// looking for a valid VoltageSource to fix an arbitrary ground
+			dprintln("F.<init>: floating!")
+			var found = false
+			for(comp in circuit.components) {
+				if(comp is VoltageSource) {
+					dprintln("F.<init>: floating: ground $comp pin 1 (node ${comp.node(1)}")
+					comp.connect(1, circuit.ground)
+					found = true
+					break
+				}
+			}
+			if(!found) println("WARN: F.<init>: floating circuit and no VSource; the matrix is likely underconstrained.")
+		}
+	}
+
+	companion object {
+		@JvmStatic
+		fun main(args: Array<String>) {
+			val falstad = """${'$'} 1 0.000005 10.20027730826997 63 10 62
+v 112 368 112 48 0 0 40 10 0 0 0.5
+w 112 48 240 48 0
+r 240 48 240 208 0 10000
+r 240 208 240 368 0 10000
+w 112 368 240 368 0
+O 240 208 304 208 1
+w 240 48 432 48 0
+w 240 368 432 368 0
+r 432 48 432 128 0 10000
+r 432 128 432 208 0 10000
+r 432 208 432 288 0 10000
+r 432 288 432 368 0 10000
+O 432 128 496 128 1
+O 432 208 496 208 1
+O 432 288 496 288 1
+"""
+			val falstad2 = """${'$'} 1 0.000005 10.20027730826997 50 5 50
+r 256 176 256 304 0 100
+172 304 176 304 128 0 7 5 5 0 0 0.5 Voltage
+g 256 336 256 352 0
+w 256 304 256 336 1
+r 352 176 352 304 0 1000
+w 352 304 352 336 1
+g 352 336 352 352 0
+w 304 176 352 176 0
+w 256 176 304 176 0
+"""
+
+			val f = Falstad(falstad)
+			f.circuit.step(0.05)
+			println("$f:\n${f.source}\n${f.roots}\n${f.refs}\n${f.grounds}\n\n${f.circuit}")
+
+			f.circuit.components.forEach {
+				println("$it:")
+				when(it) {
+					is Resistor -> println("r.i = ${it.current}")
+				}
+			}
+
+			println("nodes:")
+			f.circuit.nodes.forEach {
+				println(" - ${it.get() ?: "[removed]"}: ${it.get()?.potential ?: 0.0}V")
+			}
+
+			println("outputs:")
+			f.outputNodes.withIndex().forEach {
+				println("${it.index}: ${it.value.potential}V @${it.value.index}")
+			}
+
+			FileOutputStream("falstad.dot").bufferedWriter().also {
+				it.write(f.circuit.toDot())
+			}.close()
+		}
+	}
+}

--- a/core/src/main/kotlin/org/eln2/load/FalstadBacking.kt
+++ b/core/src/main/kotlin/org/eln2/load/FalstadBacking.kt
@@ -101,7 +101,7 @@ w 256 176 304 176 0
 					}
 				}
 			}
-			/*for (node in componentMap) {
+			for (node in componentMap) {
 				val components = node.value
 				println(components)
 				for (comp in components) {
@@ -113,13 +113,14 @@ w 256 176 304 176 0
 						}
 					}
 				}
-			}*/
+			}
 			for (component in componentMap.map { it.value }.map { it.keys }) {
 				component.forEach { println(it) }
 			}
 			for (component in circuit.components) {
 				println(component)
 			}
+			circuit.step(0.05)
 			return circuit
 		}
 

--- a/core/src/main/kotlin/org/eln2/parsers/falstad/components/generic/InterpretGlobals.kt
+++ b/core/src/main/kotlin/org/eln2/parsers/falstad/components/generic/InterpretGlobals.kt
@@ -1,0 +1,16 @@
+package org.eln2.parsers.falstad.components.generic
+
+import org.eln2.parsers.falstad.CCData
+import org.eln2.parsers.falstad.IComponentConstructor
+
+/**
+ * InterpretGlobals
+ *
+ * Takes the information from Falstad's circuit settings operator ($)
+ */
+class InterpretGlobals: IComponentConstructor {
+	override fun construct(ccd: CCData) {
+		ccd.falstad.nominalTimestep = ccd.line.getDouble(2)
+		ccd.pins = 0
+	}
+}

--- a/core/src/main/kotlin/org/eln2/parsers/falstad/components/generic/OutputProbe.kt
+++ b/core/src/main/kotlin/org/eln2/parsers/falstad/components/generic/OutputProbe.kt
@@ -1,0 +1,32 @@
+package org.eln2.parsers.falstad.components.generic
+
+import org.eln2.parsers.falstad.CCData
+import org.eln2.parsers.falstad.IComponentConstructor
+import org.eln2.parsers.falstad.PinRef
+import org.eln2.parsers.falstad.PosSet
+import org.eln2.sim.electrical.mna.component.Resistor
+
+/**
+ * Output Probe
+ *
+ * Falstad's Output Probe - shows the voltage of a particular node in the circuit.
+ */
+class OutputProbe: IComponentConstructor {
+	companion object {
+		val HIGH_IMPEDANCE = Double.POSITIVE_INFINITY
+	}
+
+	override fun construct(ccd: CCData) {
+		val r = Resistor()
+		r.resistance = HIGH_IMPEDANCE
+		ccd.circuit.add(r)
+		r.connect(1, ccd.circuit.ground)
+
+		val pp = (ccd.falstad.getPin(ccd.pos).representative as PosSet)
+		val pr = PinRef(r, 0)
+		ccd.falstad.addPinRef(pp, pr)
+		ccd.falstad.addOutput(pr)
+
+		ccd.pins = 1
+	}
+}

--- a/core/src/main/kotlin/org/eln2/parsers/falstad/components/generic/WireConstructor.kt
+++ b/core/src/main/kotlin/org/eln2/parsers/falstad/components/generic/WireConstructor.kt
@@ -1,0 +1,16 @@
+package org.eln2.parsers.falstad.components.generic
+
+import org.eln2.parsers.falstad.CCData
+import org.eln2.parsers.falstad.IComponentConstructor
+
+/**
+ * Wire Constructor
+ *
+ * Falstad's wires have 0 ohms of resistance, so we should try to compress them into the same node in the MNA
+ */
+class WireConstructor: IComponentConstructor {
+	override fun construct(ccd: CCData) {
+		ccd.falstad.getPin(ccd.pos)
+			.unite(ccd.falstad.getPin(ccd.neg))
+	}
+}

--- a/core/src/main/kotlin/org/eln2/parsers/falstad/components/passive/CapacitorConstructor.kt
+++ b/core/src/main/kotlin/org/eln2/parsers/falstad/components/passive/CapacitorConstructor.kt
@@ -1,0 +1,20 @@
+package org.eln2.parsers.falstad.components.passive
+
+import org.eln2.parsers.falstad.CCData
+import org.eln2.parsers.falstad.PoleConstructor
+import org.eln2.sim.electrical.mna.component.Capacitor
+import org.eln2.sim.electrical.mna.component.Component
+
+/**
+ * Capacitor Constructor
+ *
+ * Basic Falstad Capacitor
+ */
+class CapacitorConstructor: PoleConstructor() {
+	override fun component(ccd: CCData) = Capacitor()
+	override fun configure(ccd: CCData, cmp: Component) {
+		val c = (cmp as Capacitor)
+		c.c = ccd.data[0].toDouble()
+		c.lastI = ccd.data[1].toDouble()
+	}
+}

--- a/core/src/main/kotlin/org/eln2/parsers/falstad/components/passive/InductorConstructor.kt
+++ b/core/src/main/kotlin/org/eln2/parsers/falstad/components/passive/InductorConstructor.kt
@@ -1,0 +1,20 @@
+package org.eln2.parsers.falstad.components.passive
+
+import org.eln2.parsers.falstad.CCData
+import org.eln2.parsers.falstad.PoleConstructor
+import org.eln2.sim.electrical.mna.component.Component
+import org.eln2.sim.electrical.mna.component.Inductor
+
+/**
+ * Inductor Constructor
+ *
+ * Basic Falstad Inductor
+ */
+class InductorConstructor: PoleConstructor() {
+	override fun component(ccd: CCData) = Inductor()
+	override fun configure(ccd: CCData, cmp: Component) {
+		val l = (cmp as Inductor)
+		l.h = ccd.data[0].toDouble()
+		l.lastI = ccd.data[1].toDouble()
+	}
+}

--- a/core/src/main/kotlin/org/eln2/parsers/falstad/components/passive/ResistorConstructor.kt
+++ b/core/src/main/kotlin/org/eln2/parsers/falstad/components/passive/ResistorConstructor.kt
@@ -1,0 +1,18 @@
+package org.eln2.parsers.falstad.components.passive
+
+import org.eln2.parsers.falstad.CCData
+import org.eln2.parsers.falstad.PoleConstructor
+import org.eln2.sim.electrical.mna.component.Component
+import org.eln2.sim.electrical.mna.component.Resistor
+
+/**
+ * Resistor Constructor
+ *
+ * Basic Falstad Resistor
+ */
+class ResistorConstructor: PoleConstructor() {
+	override fun component(ccd: CCData) = Resistor()
+	override fun configure(ccd: CCData, cmp: Component) {
+		(cmp as Resistor).resistance = ccd.data[0].toDouble()
+	}
+}

--- a/core/src/main/kotlin/org/eln2/parsers/falstad/components/sources/CurrentSourceConstructor.kt
+++ b/core/src/main/kotlin/org/eln2/parsers/falstad/components/sources/CurrentSourceConstructor.kt
@@ -1,0 +1,18 @@
+package org.eln2.parsers.falstad.components.sources
+
+import org.eln2.parsers.falstad.CCData
+import org.eln2.parsers.falstad.PoleConstructor
+import org.eln2.sim.electrical.mna.component.Component
+import org.eln2.sim.electrical.mna.component.CurrentSource
+
+/**
+ * Current Source Constructor
+ *
+ * Falstad basic Current Source
+ */
+class CurrentSourceConstructor: PoleConstructor() {
+	override fun component(ccd: CCData) = CurrentSource()
+	override fun configure(ccd: CCData, cmp: Component) {
+		(cmp as CurrentSource).current = ccd.data[0].toDouble()
+	}
+}

--- a/core/src/main/kotlin/org/eln2/parsers/falstad/components/sources/GroundConstructor.kt
+++ b/core/src/main/kotlin/org/eln2/parsers/falstad/components/sources/GroundConstructor.kt
@@ -1,0 +1,19 @@
+package org.eln2.parsers.falstad.components.sources
+
+import org.eln2.parsers.falstad.CCData
+import org.eln2.parsers.falstad.IComponentConstructor
+
+/**
+ * Ground Constructor
+ *
+ * Falstad's basic ground pin. Sets a node as being a ground connected node.
+ */
+class GroundConstructor: IComponentConstructor {
+	override fun construct(ccd: CCData) {
+		ccd.pins = 1
+		ccd.falstad.addGround(
+			ccd.falstad.getPin(ccd.pinPositions[0])
+		)
+		ccd.falstad.floating = false
+	}
+}

--- a/core/src/main/kotlin/org/eln2/parsers/falstad/components/sources/VoltageRailConstructor.kt
+++ b/core/src/main/kotlin/org/eln2/parsers/falstad/components/sources/VoltageRailConstructor.kt
@@ -1,0 +1,22 @@
+package org.eln2.parsers.falstad.components.sources
+
+import org.eln2.parsers.falstad.CCData
+import org.eln2.parsers.falstad.PoleConstructor
+import org.eln2.sim.electrical.mna.component.Component
+import org.eln2.sim.electrical.mna.component.VoltageSource
+
+/**
+ * Voltage Rail Constructor
+ *
+ * Basic Falstad Voltage Rail. I think this is a one pin with shared grounds?
+ */
+class VoltageRailConstructor: PoleConstructor() {
+	override fun component(ccd: CCData) = VoltageSource()
+	override fun configure(ccd: CCData, cmp: Component) {
+		val v = (cmp as VoltageSource)
+		v.potential = ccd.data[2].toDouble() + ccd.data[3].toDouble()
+		v.connect(1, ccd.circuit.ground)  // nidx 1 should be neg
+		ccd.pins = 1  // After the above--there are two pins, but the second is dropped
+		ccd.falstad.floating = false
+	}
+}

--- a/core/src/main/kotlin/org/eln2/parsers/falstad/components/sources/VoltageSourceConstructor.kt
+++ b/core/src/main/kotlin/org/eln2/parsers/falstad/components/sources/VoltageSourceConstructor.kt
@@ -1,0 +1,18 @@
+package org.eln2.parsers.falstad.components.sources
+
+import org.eln2.parsers.falstad.CCData
+import org.eln2.parsers.falstad.PoleConstructor
+import org.eln2.sim.electrical.mna.component.Component
+import org.eln2.sim.electrical.mna.component.VoltageSource
+
+/**
+ * Voltage Source Constructor
+ *
+ * Basic Falstad voltage source. Two pin?
+ */
+class VoltageSourceConstructor: PoleConstructor() {
+	override fun component(ccd: CCData) = VoltageSource()
+	override fun configure(ccd: CCData, cmp: Component) {
+		(cmp as VoltageSource).potential = ccd.data[2].toDouble()
+	}
+}

--- a/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/Component.kt
+++ b/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/Component.kt
@@ -14,6 +14,10 @@ abstract class Component : IDetail {
 
 	/* A name for this kind of Component, used for debugging. */
 	abstract val name: String
+	
+	/* An image for this node in the images/ repository, without the .svg extension, used for debug drawing.
+	 */
+	open val imageName: String? = null
 
 	/* How many nodes this component should have. `nodes` will be of this size only AFTER this component is added to a
 	   Circuit.
@@ -84,7 +88,7 @@ abstract class Component : IDetail {
 	}
 
 	override fun toString(): String {
-		return "${this::class.java.simpleName} ${nodes.map { "${it.node.detail()}" }}"
+		return "${this::class.java.simpleName}@${System.identityHashCode(this).toString(16)} ${nodes.map { "${it.node.detail()}" }}"
 	}
 }
 

--- a/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/CurrentSource.kt
+++ b/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/CurrentSource.kt
@@ -3,7 +3,7 @@ package org.eln2.sim.electrical.mna.component
 class CurrentSource : Port() {
 	override var name: String = "is"
 
-	var i: Double = 0.0
+	var current: Double = 0.0
 		set(value) {
 			if (isInCircuit)
 				circuit!!.stampCurrentSource(pos.index, neg.index, value - field)
@@ -11,12 +11,12 @@ class CurrentSource : Port() {
 		}
 
 	override fun detail(): String {
-		return "[current source i:$i]"
+		return "[current source i:$current]"
 	}
 
 	override fun stamp() {
 		if (!isInCircuit) return
-		circuit!!.stampCurrentSource(pos.index, neg.index, i)
+		circuit!!.stampCurrentSource(pos.index, neg.index, current)
 	}
 }
 

--- a/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/Resistor.kt
+++ b/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/Resistor.kt
@@ -2,6 +2,7 @@ package org.eln2.sim.electrical.mna.component
 
 open class Resistor : Port() {
 	override var name: String = "r"
+	override val imageName = "resistor"
 
 	open var resistance: Double = 1.0
 	open val current: Double

--- a/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/VoltageSource.kt
+++ b/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/VoltageSource.kt
@@ -2,6 +2,7 @@ package org.eln2.sim.electrical.mna.component
 
 class VoltageSource : Port() {
 	override var name: String = "vs"
+	override val imageName = "vsource"
 	override val vsCount = 1
 
 	override var potential: Double = 0.0

--- a/core/src/test/kotlin/org/eln2/sim/electrical/mna/ComponentTest.kt
+++ b/core/src/test/kotlin/org/eln2/sim/electrical/mna/ComponentTest.kt
@@ -1,0 +1,5 @@
+package org.eln2.sim.electrical.mna
+
+internal class ComponentTest {
+
+}

--- a/images/resistor.svg
+++ b/images/resistor.svg
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32mm"
+   height="10.924646mm"
+   viewBox="0 0 32 10.924646"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="resistor.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="8"
+     inkscape:cx="46.841054"
+     inkscape:cy="43.591078"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1916"
+     inkscape:window-height="1044"
+     inkscape:window-x="2"
+     inkscape:window-y="15"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-286.53768)">
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 0,292 h 10 l 2,5 2,-10 2,10 2,-10 2,10 2,-10 2,5 h 8"
+       id="path4518"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+  </g>
+</svg>

--- a/images/vsource.svg
+++ b/images/vsource.svg
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22mm"
+   height="10mm"
+   viewBox="0 0 22 10"
+   version="1.1"
+   id="svg4545"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="vsource.svg">
+  <defs
+     id="defs4539" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6"
+     inkscape:cx="10.27509"
+     inkscape:cy="3.8512159"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1916"
+     inkscape:window-height="1044"
+     inkscape:window-x="2"
+     inkscape:window-y="15"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata4542">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-287)">
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 0,292 h 10 v -5 10"
+       id="path5090"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 12,294 v -4 2 h 10"
+       id="path5092"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+</svg>


### PR DESCRIPTION
This one is not as fully featured, nor is it particularly robust
(handling fissing component errors gracefully is presently deferred to
upstream code) but it gets the job done, at least with resistive
circuits. Reactive elements remain untested.

Falstad's formatting prevents an easy way to access multipins, as
learned the hard way; some significant refactoring will likely need to
be made to achieve this. The abstraction was carefully chosen to allow
this in the future.

The code is untested except by example and the coverage probably
somewhat poor. Defer more testing until stabilization and probably merge
with an origin testing branch.

The stale old code is kept for reference right now, but should probably
be removed from any final releases.