### PR TITLE
Protobuffs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,7 @@ subprojects {
 		// and lacks an 'implementation' configuration.
 		"implementation"(kotlin("stdlib-jdk8"))
 		compile("org.apache.commons", "commons-math3", "3.6.1")
+		compile("com.google.protobuf", "protobuf-java", "3.11.4")
 		// Configure testing.
 		testImplementation("org.assertj", "assertj-core", "3.12.2")
 		testImplementation("org.junit.jupiter", "junit-jupiter-api", "5.4.2")


### PR DESCRIPTION
Currently, this just adds a build import, but we also (probably) need the protobuf Gradle plugin.

- [x] Google Protobuff Gradle import.
- [ ] Protocol Buffer Gradle Plugin
- [ ] Protobuffs in classpath for builds (classes generated on runtime/builds)

Protobuffs take the `org.eln2.proto` classpath for Java and C#.