### PR TITLE
Add MultiMaps

### DIFF
--- a/core/src/main/kotlin/org/eln2/data/MultiMap.kt
+++ b/core/src/main/kotlin/org/eln2/data/MultiMap.kt
@@ -60,6 +60,11 @@ interface MultiMap<K, V> {
 	val entriesSize: Int get() = entries.map { 1 }.sum()
 }
 
+/**
+ * An implementor of [MultiMap] using the Kotlin stdlib.
+ *
+ * This class is defined here using a Map<K, Set<V>> idiom which is compatible with the Kotlin stdlib. Other, more performant implementations exist, and can be swapped in here if needed.
+ */
 class SetMapMultiMap<K, V>(iter: Iterator<Pair<K, V>>): MultiMap<K, V> {
 	/**
 	 * Internally implements the MultiMap interface as a Map<K, Set<V>>.

--- a/core/src/main/kotlin/org/eln2/data/MultiMap.kt
+++ b/core/src/main/kotlin/org/eln2/data/MultiMap.kt
@@ -1,0 +1,192 @@
+package org.eln2.data
+
+/**
+ * A helper class for representing a mapping as a Map.Entry.
+ */
+data class MultiMapEntry<K, V>(override val key: K, override val value: V): Map.Entry<K, V>
+
+/**
+ * A MultiMap: a data structure that maps one key (K) to zero or more values (V).
+ *
+ * This is in contrast to the usual Map, which maps one key to at most one value.
+ *
+ */
+interface MultiMap<K, V> {
+	/**
+	 * Tests whether a key [k] is in the MultiMap.
+	 *
+	 * This is true if k is associated with at least one value.
+	 */
+	operator fun contains(k: K): Boolean = get(k).isNotEmpty()
+
+	/**
+	 * Get the set of all values associated with key [k].
+	 */
+	operator fun get(k: K): Set<V>
+
+	/**
+	 * An iterator over every Entry<K, Set<V>>, of size keySize.
+	 */
+	val keyMapping: Iterable<Map.Entry<K, Set<V>>>
+	/**
+	 * The number of keys, value sets, and keyMapping entries in this MultiMap.
+	 */
+	val keyMappingSize: Int get() = keyMapping.map { 1 }.sum()
+	/**
+	 * The set of all keys.
+	 */
+	val keys: Set<K> get() = keyMapping.map {(k, _) -> k }.toSet()
+	/**
+	 * The set of all sets of values.
+	 * 
+	 * This will have the same size as keySize.
+	 */
+	val valueSets: Collection<Set<V>> get() = keyMapping.map {(_, vs) -> vs}
+	/**
+	 * The unique values in this MultiMap.
+	 */
+	val uniqueValues: Set<V>
+	/**
+	 * The number of unique values in this MultiMap.
+	 */
+	val uniqueValuesSize: Int get() = uniqueValues.size
+	/**
+	 * An iterator over every Entry<K, V>, where K may be repeated for each value.
+	 */
+	val entries: Iterable<Map.Entry<K, V>>
+	/**
+	 * The number of pairings in this MultiMap.
+	 */
+	val entriesSize: Int get() = entries.map { 1 }.sum()
+}
+
+class SetMapMultiMap<K, V>(iter: Iterator<Pair<K, V>>): MultiMap<K, V> {
+	/**
+	 * Internally implements the MultiMap interface as a Map<K, Set<V>>.
+	 */
+	val map: Map<K, Set<V>> = with(mutableMapOf<K, MutableSet<V>>()) {
+		iter.forEach { (k, v) -> getOrElse(k, { mutableSetOf() }).add(v) }
+		entries.associate { (k, v) -> Pair(k, v.toSet()) }
+	}.toMap()
+
+	constructor(): this(emptyList<Pair<K, V>>().iterator())
+
+	override fun get(k: K): Set<V> = map.get(k) ?: emptySet()
+
+	override val keyMapping: Iterable<Map.Entry<K, Set<V>>> = map.entries
+	override val keyMappingSize: Int = map.size
+	override val keys: Set<K> get() = map.keys
+	override val valueSets: Collection<Set<V>> get() = map.values
+	override val uniqueValues: Set<V> get() = map.values.fold(emptySet()) { next, acc -> acc.union(next) }
+	override val entries: Iterable<Map.Entry<K, V>> get() = map.entries.flatMap { (k, vs) -> vs.map { MultiMapEntry(k, it) }}
+}
+
+/**
+ * A Mutable version of the [MultiMap] interface.
+ */
+interface MutableMultiMap<K, V>: MultiMap<K, V> {
+	/**
+	 * Get the set of values for the key [k].
+	 *
+	 * Note that the return is mutable; one can add or remove entries from this map by mutating it.
+	 */
+	override operator fun get(k: K): MutableSet<V>
+
+	/**
+	 * Add an association from [k] to [v] (in addition to any other associations involving [k] or [v]).
+	 */
+	operator fun set(k: K, v: V) = get(k).add(v)
+
+	/**
+	 * Clear all values associated with the key [k].
+	 */
+	fun clear(k: K)
+
+	/**
+	 * Remove an association between [k] and [v].
+	 *
+	 * If the map no longer contains [k], [clear] is invoked (as it usually performs some implementation-specific cleanup).
+	 */
+	fun remove(k: K, v: V) {
+		val s = get(k)
+		s.remove(v)
+		if (s.isEmpty()) clear(k)
+	}
+}
+
+/**
+ * An implementor of [MutableMultiMap] using the Kotlin stdlib.
+ *
+ * This class is defined here using a MutableMap<K, MutableSet<V>> idiom which is compatible with the Kotlin stdlib. Other, more performant implementations exist, and can be swapped in here if needed.
+ */
+class MutableSetMapMultiMap<K, V>: MutableMultiMap<K, V> {
+	val map: MutableMap<K, MutableSet<V>> = mutableMapOf()
+
+	constructor(iter: Iterator<Pair<K, V>>) {
+		iter.forEach { (k, v) -> set(k, v) }
+	}
+
+	override operator fun get(k: K): MutableSet<V> = map.getOrElse(k, { mutableSetOf() })
+
+	override fun clear(k: K) {
+		map.remove(k)
+	}
+
+	override val keyMapping: Iterable<Map.Entry<K, Set<V>>> = map.entries
+	override val keyMappingSize: Int = map.size
+	override val keys get() = map.keys
+	override val valueSets: Collection<Set<V>> = map.values
+	override val uniqueValues: Set<V> get() = map.values.fold(emptySet()) { next, acc -> acc.union(next.toSet()) }
+	override val entries: Iterable<Map.Entry<K, V>> get() = map.entries.flatMap { (k, vs) -> vs.map { MultiMapEntry(k, it) }}
+}
+
+/**
+ * Create an empty MultiMap.
+ * 
+ * The choice of map is an implementation detail, but chosen to be a good compromise for general use.
+ */
+fun<K, V> emptyMultiMap(): MultiMap<K, V> = SetMapMultiMap<K, V>()
+
+/**
+ * Creates a MultiMap over the given pairs (`a to b`).
+ *
+ * The choice of map is an implementation detail, but chosen to be a good compromise for general use.
+ */
+fun<K, V> multiMapOf(vararg pairs: Pair<K, V>): MultiMap<K, V> = SetMapMultiMap(pairs.iterator())
+
+/**
+ * Creates a MutableMultiMap over the given pairs (`a to b`).
+ *
+ * The choice of map is an implementation detail, but chosen to be a good compromise for general use.
+ */
+fun<K, V> mutableMultiMapOf(vararg pairs: Pair<K, V>): MutableMultiMap<K, V> = MutableSetMapMultiMap(pairs.iterator())
+
+/**
+ * Creates a MultiMap from the iterator over pairs (`a to b`).
+ */
+fun<K, V> Iterator<Pair<K, V>>.toMultiMap(): MultiMap<K, V> = SetMapMultiMap(this)
+
+/**
+ * Creates a MutableMultiMap from the iterator over pairs.
+ */
+fun<K, V> Iterator<Pair<K, V>>.toMutableMultiMap(): MutableMultiMap<K, V> = MutableSetMapMultiMap(this)
+
+/**
+ * Creates a MultiMap from an iterable over pairs.
+ */
+fun<K, V> Iterable<Pair<K, V>>.toMultiMap(): MultiMap<K, V> = iterator().toMultiMap()
+
+/**
+ * Creates a MutableMultiMap from an iterable over pairs.
+ */
+fun<K, V> Iterable<Pair<K, V>>.toMutableMultiMap(): MutableMultiMap<K, V> = iterator().toMutableMultiMap()
+
+/**
+ * Creates a MultiMap from a Map, with each key associated to a set of size at most one.
+ */
+fun<K, V> Map<K, V>.toMultiMap(): MultiMap<K, V> = entries.map { it.toPair() }.toMultiMap()
+
+/**
+ * Creates a MutableMultiMap from a Map, with each key associated to a set of size at most one.
+ */
+fun<K, V> Map<K, V>.toMutableMultiMap(): MutableMultiMap<K, V> = entries.map { it.toPair() }.toMutableMultiMap()

--- a/core/src/main/kotlin/org/eln2/data/MultiMap.kt
+++ b/core/src/main/kotlin/org/eln2/data/MultiMap.kt
@@ -34,46 +34,55 @@ interface MultiMap<K, V> {
 		return if(iter.hasNext()) iter.next() else null
 	}
 
+
+
 	/**
 	 * An iterator over every Entry<K, Set<V>>, of size keySize.
 	 */
 	val keyMapping: Iterable<Map.Entry<K, Set<V>>>
+
 	/**
 	 * The number of keys, value sets, and keyMapping entries in this MultiMap.
 	 *
-	 * The naive implementation is O(n), but implementations are encouraged to implement this more efficiently where possible.
+	 * A naive, O(n) implementation might be keyMapping.count(), but you are encouraged to implement a faster one if at all possible. Implementors should document their complexity.
 	 */
-	val keyMappingSize: Int get() = keyMapping.count()
+	val keyMappingSize: Int
+
 	/**
 	 * The set of all keys.
 	 */
 	val keys: Set<K> get() = keyMapping.map {(k, _) -> k }.toSet()
+
 	/**
 	 * The set of all sets of values.
 	 * 
 	 * This will have the same size as keySize.
 	 */
 	val valueSets: Collection<Set<V>> get() = keyMapping.map {(_, vs) -> vs}
+
 	/**
 	 * The unique values in this MultiMap.
 	 *
 	 * This is often at least O(n * UNION), where UNION is the cost of set union.
 	 */
 	val uniqueValues: Set<V>
+
 	/**
 	 * The number of unique values in this MultiMap.
 	 */
 	val uniqueValuesSize: Int get() = uniqueValues.size
+
 	/**
 	 * An iterator over every Entry<K, V>, where K may be repeated for each value.
 	 */
 	val entries: Iterable<Map.Entry<K, V>>
+
 	/**
 	 * The number of pairings in this MultiMap.
 	 *
-	 * The naive implementation is O(n), but implementations are encouraged to implement this more efficiently where possible.
+	 * A naive, O(n) implementation might be entries.count(), but you are encouraged to implement a faster one if at all possible. Implementors should document their complexity.
 	 */
-	val entriesSize: Int get() = entries.count()
+	val entriesSize: Int
 }
 
 /**
@@ -96,11 +105,15 @@ class SetMapMultiMap<K, V>(iter: Iterator<Pair<K, V>>): MultiMap<K, V> {
 	override fun get(k: K): Set<V> = map.get(k) ?: emptySet()
 
 	override val keyMapping: Iterable<Map.Entry<K, Set<V>>> = map.entries
-	override val keyMappingSize: Int = map.size
+	/** This is an O(1) implementation of this property. */
+	override val keyMappingSize: Int get() = map.size
 	override val keys: Set<K> get() = map.keys
 	override val valueSets: Collection<Set<V>> get() = map.values
 	override val uniqueValues: Set<V> get() = map.values.fold(emptySet()) { next, acc -> acc.union(next) }
 	override val entries: Iterable<Map.Entry<K, V>> get() = map.entries.flatMap { (k, vs) -> vs.map { MultiMapEntry(k, it) }}
+	/** This implementation is O(keyMappingSize)--linear in the number of keys. */
+	override val entriesSize: Int
+		get() = map.entries.map { (_, vs) -> vs.size }.sum()
 }
 
 /**
@@ -155,11 +168,15 @@ class MutableSetMapMultiMap<K, V>: MutableMultiMap<K, V> {
 	}
 
 	override val keyMapping: Iterable<Map.Entry<K, Set<V>>> = map.entries
+	/** This implementation is O(1). */
 	override val keyMappingSize: Int get() = map.size
 	override val keys get() = map.keys
 	override val valueSets: Collection<Set<V>> = map.values
 	override val uniqueValues: Set<V> get() = map.values.fold(emptySet()) { next, acc -> acc.union(next.toSet()) }
 	override val entries: Iterable<Map.Entry<K, V>> get() = map.entries.flatMap { (k, vs) -> vs.map { MultiMapEntry(k, it) }}
+	/** This implementation is O(keyMappingSize). */
+	override val entriesSize: Int
+		get() = map.entries.map { (_, vs) -> vs.size }.sum()
 }
 
 /**

--- a/core/src/main/kotlin/org/eln2/data/MultiMap.kt
+++ b/core/src/main/kotlin/org/eln2/data/MultiMap.kt
@@ -167,7 +167,15 @@ class ImmutableMultiMapView<K, V>(val inner: MutableMultiMap<K, V>): MultiMap<K,
 	override val entriesSize: Int inline get() = inner.entriesSize
 }
 
+/** An [ImmutableMultiMapView] implemented using a [MutableSetMapMultiMap], constructed with an initial mapping.
+ *
+ * Note that this does not name a type.
+ */
 fun<K, V> SetMapMultiMap(iter: Iterator<Pair<K, V>>) = ImmutableMultiMapView(MutableSetMapMultiMap(iter))
+
+/**
+ * An [ImmutableMultiMapView] implemented using a [MutableSetMapMultiMap], constructed empty.
+ */
 fun<K, V> SetMapMultiMap() = ImmutableMultiMapView(MutableSetMapMultiMap<K, V>())
 
 /**

--- a/core/src/test/kotlin/org/eln2/data/SetMapMultiMapTest.kt
+++ b/core/src/test/kotlin/org/eln2/data/SetMapMultiMapTest.kt
@@ -1,0 +1,286 @@
+package org.eln2.data
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+// FIXME: abstract this so that the Mutable version below isn't LITERALLY an unmaintainable copy of this
+internal class SetMapMultiMapTest {
+
+	companion object {
+		val TEST_MAP: Map<Int, Int> = mapOf(1 to 2, 2 to 4, 4 to 8, 8 to 16, 16 to 32)
+		val TEST_MULTIMAP: List<Pair<Int, Int>> = listOf(
+			Pair(1, 2),
+			Pair(2, 1), Pair(2, 2),
+			Pair(4, 1), Pair(4, 2), Pair(4, 3), Pair(4, 4),
+			Pair(8, 1), Pair(8, 2), Pair(8, 3), Pair(8, 4), Pair(8, 5), Pair(8, 6), Pair(8, 7), Pair(8, 8)
+		)
+		val TEST_MULTIMAP_KEYS = 4
+		val TEST_MULTIMAP_UNIQUE_VALUES = 8
+		val TEST_NONKEY = 7
+	}
+
+	// FIXME: Kotlin can't seem to understand Pair<K,V> in the parameter below, so concrete types only for now
+	protected fun makeImplementation(iter: List<Pair<Int, Int>>): MultiMap<Int, Int> = SetMapMultiMap(iter.iterator())
+	
+	@Test
+	fun emptySizes() {
+		val map = makeImplementation(emptyList())
+
+		assertEquals(map.entriesSize, 0)
+		assertEquals(map.keyMappingSize, 0)
+		assertEquals(map.uniqueValuesSize, 0)
+	}
+	
+	@Test
+	fun emptyCollections() {
+		val map = makeImplementation(emptyList())
+
+		assertEquals(map.entries.count(), 0)
+		assertEquals(map.keyMapping.count(), 0)
+		assertEquals(map.uniqueValues.size, 0)
+	}
+
+	@Test
+	fun singleMapConsistency() {
+		val map = makeImplementation(TEST_MAP.entries.map { it.toPair() })
+
+		assertEquals(map.entriesSize, TEST_MAP.size)
+		assertEquals(map.entriesSize, map.entries.count())
+		assertEquals(map.keyMappingSize, TEST_MAP.size)
+		assertEquals(map.keyMappingSize, map.keyMapping.count())
+		assertEquals(map.uniqueValuesSize, TEST_MAP.size)
+		assertEquals(map.uniqueValuesSize, map.uniqueValues.size)
+
+		TEST_MAP.entries.forEach { (k, v) ->
+			assert(k in map)
+			val set = map[k]
+			assertEquals(set.size, 1)
+			assertEquals(set.iterator().next(), v)
+		}
+
+		assert(TEST_NONKEY !in map)
+		assert(map[TEST_NONKEY].isEmpty())
+	}
+
+	@Test
+	fun multiMapConsistency() {
+		val map = makeImplementation(TEST_MULTIMAP)
+
+		println("multimap keymappings ${map.keyMapping} entries: ${map.entries} size ${map.entriesSize}")
+		assertEquals(map.entriesSize, TEST_MULTIMAP.size)
+		assertEquals(map.entriesSize, map.entries.count())
+		assertEquals(map.keyMappingSize, TEST_MULTIMAP_KEYS)
+		assertEquals(map.keyMappingSize, map.keyMapping.count())
+		assertEquals(map.uniqueValuesSize, TEST_MULTIMAP_UNIQUE_VALUES)
+		assertEquals(map.uniqueValuesSize, map.uniqueValues.size)
+
+		TEST_MULTIMAP.forEach { (k, v) ->
+			assert(k in map)
+			val set = map[k]
+			assert(v in set)
+		}
+
+		map.keyMapping.forEach { (k, vs) ->
+			assertEquals(k, vs.size)
+		}
+
+		assert(TEST_NONKEY !in map)
+		assert(map[TEST_NONKEY].isEmpty())
+	}
+}
+
+internal class MutableSetMapMultiMapTest {
+	// ------------- START PASTING THE BODY OF THE CLASS ABOVE HERE --------------
+
+	companion object {
+		val TEST_MAP: Map<Int, Int> = mapOf(1 to 2, 2 to 4, 4 to 8, 8 to 16, 16 to 32)
+		val TEST_MULTIMAP: List<Pair<Int, Int>> = listOf(
+			Pair(1, 2),
+			Pair(2, 1), Pair(2, 2),
+			Pair(4, 1), Pair(4, 2), Pair(4, 3), Pair(4, 4),
+			Pair(8, 1), Pair(8, 2), Pair(8, 3), Pair(8, 4), Pair(8, 5), Pair(8, 6), Pair(8, 7), Pair(8, 8)
+		)
+		val TEST_MULTIMAP_KEYS = 4
+		val TEST_MULTIMAP_UNIQUE_VALUES = 8
+		val TEST_NONKEY = 7
+	}
+
+	// FIXME: Kotlin can't seem to understand Pair<K,V> in the parameter below, so concrete types only for now
+	protected fun makeImplementation(iter: List<Pair<Int, Int>>): MutableMultiMap<Int, Int> = MutableSetMapMultiMap(iter.iterator())
+
+	@Test
+	fun emptySizes() {
+		val map = makeImplementation(emptyList())
+
+		assertEquals(map.entriesSize, 0)
+		assertEquals(map.keyMappingSize, 0)
+		assertEquals(map.uniqueValuesSize, 0)
+	}
+
+	@Test
+	fun emptyCollections() {
+		val map = makeImplementation(emptyList())
+
+		assertEquals(map.entries.count(), 0)
+		assertEquals(map.keyMapping.count(), 0)
+		assertEquals(map.uniqueValues.size, 0)
+	}
+
+	@Test
+	fun singleMapConsistency() {
+		val map = makeImplementation(TEST_MAP.entries.map { it.toPair() })
+
+		assertEquals(map.entriesSize, TEST_MAP.size)
+		assertEquals(map.entriesSize, map.entries.count())
+		assertEquals(map.keyMappingSize, TEST_MAP.size)
+		assertEquals(map.keyMappingSize, map.keyMapping.count())
+		assertEquals(map.uniqueValuesSize, TEST_MAP.size)
+		assertEquals(map.uniqueValuesSize, map.uniqueValues.size)
+
+		TEST_MAP.entries.forEach { (k, v) ->
+			assert(k in map)
+			val set = map[k]
+			assertEquals(set.size, 1)
+			assertEquals(set.iterator().next(), v)
+		}
+
+		assert(TEST_NONKEY !in map)
+		assert(map[TEST_NONKEY].isEmpty())
+	}
+
+	@Test
+	fun multiMapConsistency() {
+		val map = makeImplementation(TEST_MULTIMAP)
+
+		assertEquals(map.entriesSize, TEST_MULTIMAP.size)
+		assertEquals(map.entriesSize, map.entries.count())
+		assertEquals(map.keyMappingSize, TEST_MULTIMAP_KEYS)
+		assertEquals(map.keyMappingSize, map.keyMapping.count())
+		assertEquals(map.uniqueValuesSize, TEST_MULTIMAP_UNIQUE_VALUES)
+		assertEquals(map.uniqueValuesSize, map.uniqueValues.size)
+
+		TEST_MULTIMAP.forEach { (k, v) ->
+			assert(k in map)
+			val set = map[k]
+			assert(v in set)
+		}
+
+		map.keyMapping.forEach { (k, vs) ->
+			assertEquals(k, vs.size)
+		}
+
+		assert(TEST_NONKEY !in map)
+		assert(map[TEST_NONKEY].isEmpty())
+	}
+	// ------------ STOP PASTING HERE --------------
+	
+	@Test
+	fun buildSingleMapWithSetOperator() {
+		val map = makeImplementation(emptyList())
+
+		TEST_MAP.entries.forEach { (k, v) ->
+			map[k] = v
+		}
+
+		assertEquals(map.entriesSize, TEST_MAP.size)
+		assertEquals(map.entriesSize, map.entries.count())
+		assertEquals(map.keyMappingSize, TEST_MAP.size)
+		assertEquals(map.keyMappingSize, map.keyMapping.count())
+		assertEquals(map.uniqueValuesSize, TEST_MAP.size)
+		assertEquals(map.uniqueValuesSize, map.uniqueValues.size)
+
+		TEST_MAP.entries.forEach { (k, v) ->
+			assert(k in map)
+			val set = map[k]
+			assertEquals(set.size, 1)
+			assertEquals(set.iterator().next(), v)
+		}
+
+		assert(TEST_NONKEY !in map)
+		assert(map[TEST_NONKEY].isEmpty())
+	}
+	
+	@Test
+	fun buildSingleMapMutatingSet() {
+		val map = makeImplementation(emptyList())
+
+		TEST_MAP.entries.forEach { (k, v) ->
+			map[k].add(v)
+		}
+
+		assertEquals(map.entriesSize, TEST_MAP.size)
+		assertEquals(map.entriesSize, map.entries.count())
+		assertEquals(map.keyMappingSize, TEST_MAP.size)
+		assertEquals(map.keyMappingSize, map.keyMapping.count())
+		assertEquals(map.uniqueValuesSize, TEST_MAP.size)
+		assertEquals(map.uniqueValuesSize, map.uniqueValues.size)
+
+		TEST_MAP.entries.forEach { (k, v) ->
+			assert(k in map)
+			val set = map[k]
+			assertEquals(set.size, 1)
+			assertEquals(set.iterator().next(), v)
+		}
+
+		assert(TEST_NONKEY !in map)
+		assert(map[TEST_NONKEY].isEmpty())
+	}
+	
+	@Test
+	fun buildMultiMapWithSetOperator() {
+		val map = makeImplementation(emptyList())
+
+		TEST_MULTIMAP.forEach { (k, v) ->
+			map[k] = v
+		}
+
+		assertEquals(map.entriesSize, TEST_MULTIMAP.size)
+		assertEquals(map.entriesSize, map.entries.count())
+		assertEquals(map.keyMappingSize, TEST_MULTIMAP_KEYS)
+		assertEquals(map.keyMappingSize, map.keyMapping.count())
+		assertEquals(map.uniqueValuesSize, TEST_MULTIMAP_UNIQUE_VALUES)
+		assertEquals(map.uniqueValuesSize, map.uniqueValues.size)
+
+		TEST_MULTIMAP.forEach { (k, v) ->
+			assert(k in map)
+			val set = map[k]
+			assert(v in set)
+		}
+
+		map.keyMapping.forEach { (k, vs) ->
+			assertEquals(k, vs.size)
+		}
+
+		assert(TEST_NONKEY !in map)
+		assert(map[TEST_NONKEY].isEmpty())
+	}
+	
+	@Test
+	fun buildMultiMapMutatingSet() {
+		val map = makeImplementation(emptyList())
+
+		TEST_MULTIMAP.forEach { (k, v) ->
+			map[k].add(v)
+		}
+
+		assertEquals(map.entriesSize, TEST_MULTIMAP.size)
+		assertEquals(map.entriesSize, map.entries.count())
+		assertEquals(map.keyMappingSize, TEST_MULTIMAP_KEYS)
+		assertEquals(map.keyMappingSize, map.keyMapping.count())
+		assertEquals(map.uniqueValuesSize, TEST_MULTIMAP_UNIQUE_VALUES)
+		assertEquals(map.uniqueValuesSize, map.uniqueValues.size)
+
+		TEST_MULTIMAP.forEach { (k, v) ->
+			assert(k in map)
+			val set = map[k]
+			assert(v in set)
+		}
+
+		map.keyMapping.forEach { (k, vs) ->
+			assertEquals(k, vs.size)
+		}
+
+		assert(TEST_NONKEY !in map)
+		assert(map[TEST_NONKEY].isEmpty())
+	}
+}

--- a/core/src/test/kotlin/org/eln2/data/SetMapMultiMapTest.kt
+++ b/core/src/test/kotlin/org/eln2/data/SetMapMultiMapTest.kt
@@ -1,23 +1,22 @@
 package org.eln2.data
 
+import org.eln2.debug.dprintln
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
+val TEST_MAP: Map<Int, Int> = mapOf(1 to 2, 2 to 4, 4 to 8, 8 to 16, 16 to 32)
+val TEST_MULTIMAP: List<Pair<Int, Int>> = listOf(
+	Pair(1, 2),
+	Pair(2, 1), Pair(2, 2),
+	Pair(4, 1), Pair(4, 2), Pair(4, 3), Pair(4, 4),
+	Pair(8, 1), Pair(8, 2), Pair(8, 3), Pair(8, 4), Pair(8, 5), Pair(8, 6), Pair(8, 7), Pair(8, 8)
+)
+val TEST_MULTIMAP_KEYS = 4
+val TEST_MULTIMAP_UNIQUE_VALUES = 8
+val TEST_NONKEY = 7
+
 // FIXME: abstract this so that the Mutable version below isn't LITERALLY an unmaintainable copy of this
 internal class SetMapMultiMapTest {
-
-	companion object {
-		val TEST_MAP: Map<Int, Int> = mapOf(1 to 2, 2 to 4, 4 to 8, 8 to 16, 16 to 32)
-		val TEST_MULTIMAP: List<Pair<Int, Int>> = listOf(
-			Pair(1, 2),
-			Pair(2, 1), Pair(2, 2),
-			Pair(4, 1), Pair(4, 2), Pair(4, 3), Pair(4, 4),
-			Pair(8, 1), Pair(8, 2), Pair(8, 3), Pair(8, 4), Pair(8, 5), Pair(8, 6), Pair(8, 7), Pair(8, 8)
-		)
-		val TEST_MULTIMAP_KEYS = 4
-		val TEST_MULTIMAP_UNIQUE_VALUES = 8
-		val TEST_NONKEY = 7
-	}
 
 	// FIXME: Kotlin can't seem to understand Pair<K,V> in the parameter below, so concrete types only for now
 	protected fun makeImplementation(iter: List<Pair<Int, Int>>): MultiMap<Int, Int> = SetMapMultiMap(iter.iterator())
@@ -65,8 +64,8 @@ internal class SetMapMultiMapTest {
 	@Test
 	fun multiMapConsistency() {
 		val map = makeImplementation(TEST_MULTIMAP)
-
-		println("multimap keymappings ${map.keyMapping} entries: ${map.entries} size ${map.entriesSize}")
+		
+		dprintln("multimap keymappings ${map.keyMapping} entries: ${map.entries} size ${map.entriesSize}")
 		assertEquals(map.entriesSize, TEST_MULTIMAP.size)
 		assertEquals(map.entriesSize, map.entries.count())
 		assertEquals(map.keyMappingSize, TEST_MULTIMAP_KEYS)
@@ -91,19 +90,6 @@ internal class SetMapMultiMapTest {
 
 internal class MutableSetMapMultiMapTest {
 	// ------------- START PASTING THE BODY OF THE CLASS ABOVE HERE --------------
-
-	companion object {
-		val TEST_MAP: Map<Int, Int> = mapOf(1 to 2, 2 to 4, 4 to 8, 8 to 16, 16 to 32)
-		val TEST_MULTIMAP: List<Pair<Int, Int>> = listOf(
-			Pair(1, 2),
-			Pair(2, 1), Pair(2, 2),
-			Pair(4, 1), Pair(4, 2), Pair(4, 3), Pair(4, 4),
-			Pair(8, 1), Pair(8, 2), Pair(8, 3), Pair(8, 4), Pair(8, 5), Pair(8, 6), Pair(8, 7), Pair(8, 8)
-		)
-		val TEST_MULTIMAP_KEYS = 4
-		val TEST_MULTIMAP_UNIQUE_VALUES = 8
-		val TEST_NONKEY = 7
-	}
 
 	// FIXME: Kotlin can't seem to understand Pair<K,V> in the parameter below, so concrete types only for now
 	protected fun makeImplementation(iter: List<Pair<Int, Int>>): MutableMultiMap<Int, Int> = MutableSetMapMultiMap(iter.iterator())
@@ -279,6 +265,64 @@ internal class MutableSetMapMultiMapTest {
 		map.keyMapping.forEach { (k, vs) ->
 			assertEquals(k, vs.size)
 		}
+
+		assert(TEST_NONKEY !in map)
+		assert(map[TEST_NONKEY].isEmpty())
+	}
+	
+	@Test
+	fun nonUniqueValues() {
+		val map = makeImplementation(emptyList())
+		val (key, value) = Pair(1, 3)
+
+		assert(key !in map)
+		assert(map[key].isEmpty())
+		assertEquals(map.uniqueValuesSize, 0)
+		
+		map[key] = value
+
+		assert(key in map)
+		assertEquals(map[key].size, 1)
+		assertEquals(map.one(key), value)
+		assertEquals(map.uniqueValuesSize, 1)
+
+		map[key] = value
+
+		assert(key in map)
+		assertEquals(map[key].size, 1)
+		assertEquals(map.one(key), value)
+		assertEquals(map.uniqueValuesSize, 1)
+
+		map[key].add(value)
+
+		assert(key in map)
+		assertEquals(map[key].size, 1)
+		assertEquals(map.one(key), value)
+		assertEquals(map.uniqueValuesSize, 1)
+
+		map.remove(key, value)
+
+		assert(key !in map)
+		assert(map[key].isEmpty())
+		assertEquals(map.uniqueValuesSize, 0)
+	}
+	
+	@Test
+	fun additionRemoval() {
+		val map = makeImplementation(TEST_MULTIMAP)
+		val value = 5
+
+		assert(TEST_NONKEY !in map)
+		assert(map[TEST_NONKEY].isEmpty())
+
+		// After this point, the name becomes a bit of a lie...
+		map[TEST_NONKEY] = value
+
+		assert(TEST_NONKEY in map)
+		assertEquals(map[TEST_NONKEY].size, 1)
+		assertEquals(map.one(TEST_NONKEY), value)
+
+		map.remove(TEST_NONKEY, value)
 
 		assert(TEST_NONKEY !in map)
 		assert(map[TEST_NONKEY].isEmpty())


### PR DESCRIPTION
MultiMaps relax the restriction that every K can associate with at most
one V; in general, a query for K can result in any set of V, including
empty ones.

These were already used in a few areas of code, refactored to consider
them.