### PR TITLE
Fixing gradle and modbus

### DIFF
--- a/integration-mc1-15/build.gradle
+++ b/integration-mc1-15/build.gradle
@@ -12,14 +12,26 @@ buildscript {
     dependencies {
         classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '3.+', changing: true
     }
+    repositories{
+        maven { url = "https://dl.bintray.com/kotlin/kotlin-eap" }
+    }
+    dependencies {
+        // Make sure to use the correct version
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4-M1"
+    }
 }
 apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'maven-publish'
+apply plugin: 'kotlin'
 
 archivesBaseName = "eln2-mc1.15"
 
 repositories {
 	maven { url 'https://maven.mcmoddev.com' }
+    maven {
+        name = "Kotlin Early Access"
+        url = "https://dl.bintray.com/kotlin/kotlin-eap"
+    }
 	maven {
 		name = 'kotlinforforge'
 		url = 'https://thedarkcolour.github.io/KotlinForForge/'

--- a/integration-mc1-15/src/main/java/org/eln2/Eln2Wrapper.java
+++ b/integration-mc1-15/src/main/java/org/eln2/Eln2Wrapper.java
@@ -9,7 +9,7 @@ import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent;
 import net.minecraftforge.fml.event.lifecycle.InterModProcessEvent;
 import net.minecraftforge.fml.event.server.FMLServerStartingEvent;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import thedarkcolour.kotlinforforge.eventbus.KotlinEventBus;
 
 import java.util.stream.Collectors;
 
@@ -22,14 +22,15 @@ import java.util.stream.Collectors;
 public class Eln2Wrapper
 {
 	public Eln2Wrapper() {
+		KotlinEventBus bus = thedarkcolour.kotlinforforge.forge.ForgeKt.getMOD_BUS();
 		// Register the setup method for modloading
-		FMLJavaModLoadingContext.get().getModEventBus().addListener(this::setup);
+		bus.addListener(this::setup);
 		// Register the enqueueIMC method for modloading
-		FMLJavaModLoadingContext.get().getModEventBus().addListener(this::enqueueIMC);
+		bus.addListener(this::enqueueIMC);
 		// Register the processIMC method for modloading
-		FMLJavaModLoadingContext.get().getModEventBus().addListener(this::processIMC);
+		bus.addListener(this::processIMC);
 		// Register the doClientStuff method for modloading
-		FMLJavaModLoadingContext.get().getModEventBus().addListener(this::doClientStuff);
+		bus.addListener(this::doClientStuff);
 
 		// Register ourselves for server and other game events we are interested in
 		MinecraftForge.EVENT_BUS.register(this);

--- a/integration-mc1-15/src/main/kotlin/org/eln2/Eln2.kt
+++ b/integration-mc1-15/src/main/kotlin/org/eln2/Eln2.kt
@@ -1,16 +1,9 @@
 package org.eln2;
 
 import net.darkhax.bookshelf.registry.RegistryHelper
-import net.minecraft.item.ItemGroup
-import net.minecraft.item.ItemStack
-import net.minecraft.util.NonNullList
-import net.minecraftforge.fml.common.registry.GameRegistry
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext
-import net.minecraftforge.registries.ForgeRegistries
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
-import org.eln2.blocks.OreBlock
 import org.eln2.utils.OreGen
 
 const val MODID = "eln2"
@@ -35,7 +28,7 @@ object Eln2 {
 		ModItems.values().forEach {registry.registerItem(it.items, it.name.toLowerCase())}
 		ModBlocks.values().forEach {registry.registerBlock(it.block, it.name.toLowerCase())}
 
-		registry.initialize(FMLJavaModLoadingContext.get().modEventBus)
+		registry.initialize(thedarkcolour.kotlinforforge.forge.MOD_BUS);
 	}
 
 	/**

--- a/integration-mc1-15/src/main/resources/META-INF/mods.toml
+++ b/integration-mc1-15/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
-modLoader="javafml"
-loaderVersion="[31,)"
+modLoader="kotlinforforge"
+loaderVersion="[1.2.1,)"
 issueTrackerURL="https://github.com/eln2/eln2/issues" #optional
 
 # A list of mods - how many allowed here is determined by the individual mod loader


### PR DESCRIPTION
Made gradle work with kotlinforforge 1.2.1 and changed FMLJavaModLoadingContext to kotlinforforge's MOD_CONTEXT as recommended.