### PR TITLE
Fixes lints in files related to sim code

### DIFF
--- a/core/src/main/kotlin/org/eln2/debug/DebugPrint.kt
+++ b/core/src/main/kotlin/org/eln2/debug/DebugPrint.kt
@@ -1,3 +1,5 @@
+@file:Suppress("unused")
+
 package org.eln2.debug
 
 /**
@@ -39,12 +41,12 @@ fun dprintln() = if (DEBUG) println() else Unit
 
 /**
  * dprintln: Print's object (toString) followed by newline if DEBUG = True
- * @param debug_string The Object you want to print.
+ * @param a The Object you want to print.
  */
 fun dprintln(a: Any?) = if (DEBUG) println(a) else Unit
 
 /**
  * dprint: Print's object (toString) (with no newline)if DEBUG = True
- * @param debug_string The object you want to print
+ * @param a The object you want to print
  */
 fun dprint(a: Any?) = if (DEBUG) print(a) else Unit

--- a/core/src/main/kotlin/org/eln2/math/FunctionTable.kt
+++ b/core/src/main/kotlin/org/eln2/math/FunctionTable.kt
@@ -4,10 +4,16 @@ package org.eln2.math
  * Function Table
  *
  * Defines a function based on the values in a table. The domain of the input array starts from 0 and goes to "xMax"
- * @param point Array of double representing the reference or "y" values.
- * @param xMax The x value that corresponds to the last y value in the point array.
+ * @param _point Array of double representing the reference or "y" values.
+ * @param _xMax The x value that corresponds to the last y value in the point array.
  */
-open class FunctionTable(var point: DoubleArray, var xMax: Double, private val mode: ExtrapolationMode) : IFunction {
+open class FunctionTable(_point: DoubleArray, _xMax: Double, private val mode: ExtrapolationMode) : IFunction {
+
+    @Suppress("MemberVisibilityCanBePrivate")
+    var point: DoubleArray = _point
+
+    @Suppress("MemberVisibilityCanBePrivate")
+    var xMax: Double = _xMax
 
     /**
      * Selects which method of extrapolation to use when trying to get a value outside of the given range.

--- a/core/src/main/kotlin/org/eln2/sim/electrical/mna/Circuit.kt
+++ b/core/src/main/kotlin/org/eln2/sim/electrical/mna/Circuit.kt
@@ -26,7 +26,7 @@ val MATRIX_FORMAT = RealMatrixFormat("", "", "\t", "\n", "", "\t")
  *
  * ## Disconnections and Removal
  *
- * The current algorithm supports _only_ incremental addition and connection; removal is _not_ directly supported, as it has the potential to sever the connected component of the circuit. For this reason, online removal is delegated to a higher layer which can track the connected components (such as [Space]).
+ * The current algorithm supports _only_ incremental addition and connection; removal is _not_ directly supported, as it has the potential to sever the connected component of the circuit. For this reason, online removal is delegated to a higher layer which can track the connected components (such as Space).
  *
  * The best way to simulate removal or disconnection is to rebuild the Circuit (or possibly Circuits, if disconnection occurred) without the components and connections to remove. It is safe to transfer ownership of a Component to a new Circuit, such that it retains its state, but note that it will be entirely disconnected.
  *
@@ -56,7 +56,7 @@ val MATRIX_FORMAT = RealMatrixFormat("", "", "\t", "\n", "", "\t")
  *
  * - The connectivity matrix has entries in terms of _conductance_ (reciprocal resistance), summed over all components. Infinite resistance is zero conductance, but 0 resistance is infinite conductance, and this _will_ cause the solver to fail. Perfect, non-resistive connections are best represented by connecting the underlying nodes directly--but see the note on disconnection above that this process is hard to undo.
  * - Along similar terms, numerical stability is best when resistances are within a few orders of magnitude of each other. This library is reliant upon Java's double (likely IEEE754 binary64) and all the burdens that come with it; very high resistances will result in very small conductances, and one should expect precision loss to occur if very large and small resistances are simultaneously connected to the same Node.
- * - The ground node is privileged as being _defined_ to zero potential. The exact choice of where to put this in the circuit doesn't matter, but it is traditionally placed on the node considered to have the lowest potential, often on the negative side of a DC "main" power supply. Failing to connect this node will result in a ["floating" Circuit][Circuit.isFloating] (see, e.g., [Falstad.floating]) which is likely underconstrained, causing the solver to fail.
+ * - The ground node is privileged as being _defined_ to zero potential. The exact choice of where to put this in the circuit doesn't matter, but it is traditionally placed on the node considered to have the lowest potential, often on the negative side of a DC "main" power supply. Failing to connect this node will result in a ["floating" Circuit][Circuit.isFloating] (see, e.g., Falstad.floating) which is likely underconstrained, causing the solver to fail.
  * - This point bears reiteration: the node voltages for a "connected circuit graph component" without any conductance to ground (or infinite resistance) is underconstrained, and will cause the solver to fail. This is mainly the reason you should rebuild a Circuit after disconnecting or removing Components.
  *
  * A successful [Circuit.step] does not guarantee that the values are valid; it is possible for the solver to return, e.g., NaN values. Any logic interfacing the Circuit should be prepared to receive invalid values gracefully.
@@ -67,9 +67,7 @@ val MATRIX_FORMAT = RealMatrixFormat("", "", "\t", "\n", "", "\t")
  *
  * The linear algebra library is presently [Apache Commons Math](http://commons.apache.org/proper/commons-math/), but this is subject to change--and distinct Circuits need not use the same underlying implementation.
  *
- * The MNA algorithm itself is heavily borrowed from [Erik Cheever's Algorithmic MNA resource][MNA].
- *
- * [MNA]: https://lpsa.swarthmore.edu/Systems/Electrical/mna/MNA3.html
+ * The MNA algorithm itself is heavily borrowed from [Erik Cheever's Algorithmic MNA resource][https://lpsa.swarthmore.edu/Systems/Electrical/mna/MNA3.html].
  */
 class Circuit {
 
@@ -133,7 +131,9 @@ class Circuit {
      *
      * This is exactly the value returned from [step]; it is false when [computeResult] fails to solve or write out its results.
      */
+    @Suppress("MemberVisibilityCanBePrivate")
     var success = true
+        private set
 
     /**
      * The [Component]s added to this Circuit.
@@ -149,22 +149,24 @@ class Circuit {
      *
      * This does not include the [ground] NodeRef owned by the Circuit.
      */
-    val compNodeMap = WeakHashMap<NodeRef, Component>()
+    private val compNodeMap = WeakHashMap<NodeRef, Component>()
 
     /**
      * A map from [VSource] to the owning [Component].
      */
     // These don't merge, but keep this collection weak anyway so the size reflects component removal.
-    val compVsMap = WeakHashMap<VSource, Component>()
+    private val compVsMap = WeakHashMap<VSource, Component>()
 
     /**
      * A list of closures to call before the Circuit step runs.
      */
+    @Suppress("MemberVisibilityCanBePrivate")
     val preProcess = WeakHashMap<IProcess, Unit>()
 
     /**
      * A list of closures to call after the Circuit step finishes.
      */
+    @Suppress("MemberVisibilityCanBePrivate")
     val postProcess = WeakHashMap<IProcess, Unit>()
 
     // These fields are only for the solver--don't use them casually elsewhere
@@ -173,9 +175,7 @@ class Circuit {
      *
      * This matrix is square of size (nodes + vsources), with the upper-left square nodes-size matrix representing the conductances, and the two (nodes x vsources) rectangular matrices representing the connectivity of the voltage sources.
      *
-     * It is the "A Matrix" in the [MNA Algorithm][MNA].
-     *
-     * [MNA]: https://lpsa.swarthmore.edu/Systems/Electrical/mna/MNA3.html
+     * It is the "A Matrix" in the [MNA Algorithm][https://lpsa.swarthmore.edu/Systems/Electrical/mna/MNA3.html].
      */
     internal var matrix: RealMatrix? = null
 
@@ -184,9 +184,7 @@ class Circuit {
      *
      * This is a column vector of size (nodes + vsources); the first (nodes) elements are independent currents into the node (the sums of signed contributions of current sources), and the last (vsources) elements are the voltage source values.
      *
-     * This is the "z matrix" in the [MNA Algorithm][MNA].
-     *
-     * [MNA]: https://lpsa.swarthmore.edu/Systems/Electrical/mna/MNA3.html
+     * This is the "z matrix" in the [MNA Algorithm][https://lpsa.swarthmore.edu/Systems/Electrical/mna/MNA3.html].
      */
     internal var knowns: RealVector? = null
 
@@ -213,23 +211,23 @@ class Circuit {
      *
      * The order is significant; their position is their index into the rows and columns of [matrix] and [knowns] (offset, as need be, by the size of [nodes]). This is available via [VSource.index] after a [buildMatrix].
      */
-    internal var voltageSources: List<WeakReference<VSource>> = emptyList()
+    private var voltageSources: List<WeakReference<VSource>> = emptyList()
 
     /**
      * Add a value to a given row and column of [matrix].
      *
-     * [a] and [b] should be indices of [Node]s; that is, they should be nonnegative and less than the length of [nodes]. Thus, these index into the "G submatrix" as expressed in the [MNA Algorithm][MNA]. Since this matrix should be symmetric, this method is usually invoked twice, the latter with [b] and [a] swapped.
+     * [a] and [b] should be indices of [Node]s; that is, they should be nonnegative and less than the length of [nodes]. Thus, these index into the "G submatrix" as expressed in the [MNA Algorithm][https://lpsa.swarthmore.edu/Systems/Electrical/mna/MNA3.html]. Since this matrix should be symmetric, this method is usually invoked twice, the latter with [b] and [a] swapped.
      *
      * The interpretation, according to Falstad, is as follows: if the potential of [b] changes by `dV`, then the current into node [a] should change by [x] * `dV`. The unit of [x] is Siemens (reciprocal Ohms).
      *
      * This is the lowest level function that manipulates [matrix]; it is usually called via [stampResistor] and [stampVoltageSource]. These should only be called from [Component.stamp].
      *
-     * [MNA]: https://lpsa.swarthmore.edu/Systems/Electrical/mna/MNA3.html
      */
     /* From Falstad: declare that a potential change dV in node b changes the current in node a by x*dV, complicated
 	   slightly by independent voltage sources. The unit of x is Siemens, reciprocal Ohms, a unit of conductance.
 	 */
-    fun stampMatrix(a: Int, b: Int, x: Double) {
+    @Suppress("MemberVisibilityCanBePrivate")
+    internal fun stampMatrix(a: Int, b: Int, x: Double) {
         dprintln("C.sM $a $b $x")
         if (a < 0 || b < 0) return
         matrix!!.addToEntry(a, b, x)
@@ -243,7 +241,8 @@ class Circuit {
      *
      * This is the lowest level function that manipulates [knowns]; it is usually called via [stampVoltageChange] and [stampCurrentSource]. These should only be called from [Component.stamp].
      */
-    fun stampKnown(i: Int, x: Double) {
+    @Suppress("MemberVisibilityCanBePrivate")
+    internal fun stampKnown(i: Int, x: Double) {
         dprintln("C.sK $i $x")
         if (i < 0) return
         knowns!!.addToEntry(i, x)
@@ -255,7 +254,7 @@ class Circuit {
      *
      * This calls [stampKnown] internally. It should usually be called from a method on a [Component] with a valid [VSource].
      */
-    fun stampVoltageChange(i: Int, x: Double) {
+    internal fun stampVoltageChange(i: Int, x: Double) {
         stampKnown(i + nodes.size, x)
     }
 
@@ -264,7 +263,7 @@ class Circuit {
      *
      * This calls [stampMatrix] internally. It should only ever be called from [Component.stamp].
      */
-    fun stampResistor(a: Int, b: Int, r: Double) {
+    internal fun stampResistor(a: Int, b: Int, r: Double) {
         dprintln("C.sR $a $b $r")
         val c = 1 / r
         if (!c.isFinite()) throw IllegalArgumentException("resistance $r is invalid")
@@ -281,7 +280,7 @@ class Circuit {
      *
      * This calls [stampMatrix] and [stampKnown] internally. It should only ever be called from [Component.stamp].
      */
-    fun stampVoltageSource(pos: Int, neg: Int, num: Int, v: Double) {
+    internal fun stampVoltageSource(pos: Int, neg: Int, num: Int, v: Double) {
         val vs = num + nodes.size
         stampMatrix(vs, neg, -1.0)
         stampMatrix(vs, pos, 1.0)
@@ -295,7 +294,7 @@ class Circuit {
      *
      * This calls [stampKnown] internally.
      */
-    fun stampCurrentSource(pos: Int, neg: Int, i: Double) {
+    internal fun stampCurrentSource(pos: Int, neg: Int, i: Double) {
         stampKnown(pos, -i)
         stampKnown(neg, i)
     }
@@ -327,12 +326,12 @@ class Circuit {
         comp.circuit = this
         for (i in 0 until comp.nodeCount) {
             val n = NodeRef(Node(this))
-            compNodeMap.put(n, comp)
+            compNodeMap[n] = comp
             comp.nodes.add(n)
         }
         for (i in 0 until comp.vsCount) {
             val vs = VSource(this)
-            compVsMap.put(vs, comp)
+            compVsMap[vs] = comp
             comp.vsources.add(vs)
         }
         comp.added()
@@ -344,7 +343,7 @@ class Circuit {
     /**
      * Rmove all of the [Component]s in the vararg list.
      */
-
+    @Suppress("unused")
     fun remove(vararg comps: Component) {
         for (comp in comps) remove(comp)
     }
@@ -376,11 +375,12 @@ class Circuit {
      *
      * A floating circuit is likely to fail to [step], as it is underconstrained. Fixing this requires unifying any node with [ground]--any one will do, though it is traditionally the lowest-potential node of the Circuit.
      */
+    @Suppress("MemberVisibilityCanBePrivate")
     val isFloating: Boolean
         get() {
             if (componentsChanged || connectivityChanged) buildMatrix()
-            return !components.any {
-                it.nodes.any {
+            return !components.any {component ->
+                component.nodes.any {
                     it.node == ground.node
                 }
             }
@@ -397,15 +397,15 @@ class Circuit {
      */
     // Step 1: Whenever the number of components, or their nodal connectivity (not resistances, e.g.) changes, allocate
     // a matrix of appropriate size.
-    protected fun buildMatrix() {
+    internal fun buildMatrix() {
         dprintln("C.bM")
         val nodeSet: MutableSet<Node> = mutableSetOf()
         val voltageSourceSet: MutableSet<VSource> = mutableSetOf()
 
-        components.forEach {
-            dprintln("C.bM: component $it nodes ${it.nodes.map { it.node }}")
-            nodeSet.addAll(it.nodes.map { it.node }.filter { it != ground.node })
-            voltageSourceSet.addAll(it.vsources)
+        components.forEach {component ->
+            dprintln("C.bM: component $component nodes ${component.nodes.map { it.node }}")
+            nodeSet.addAll(component.nodes.map { it.node }.filter { it != ground.node })
+            voltageSourceSet.addAll(component.vsources)
         }
 
         nodes = nodeSet.map { WeakReference(it) }.toList()
@@ -488,7 +488,7 @@ class Circuit {
 
             success = true
         } catch (e: SingularMatrixException) {
-            dprintln("Singular: ${matrix}")
+            dprintln("Singular: $matrix")
             if (matrix != null) dprint(MATRIX_FORMAT.format(matrix))
         }
     }
@@ -546,6 +546,7 @@ class Circuit {
      *
      * This is useful to visualize a circuit. (I recommend using `neato` or `fdp`; the visualization is not that good in `dot` alone, despite the name, because `dot` expects more hierarchical graphs.)
      */
+    @Suppress("unused")
     fun toDot(): String {
         val sb = StringBuilder()
         sb.append("graph {\n")

--- a/core/src/main/kotlin/org/eln2/sim/electrical/mna/Node.kt
+++ b/core/src/main/kotlin/org/eln2/sim/electrical/mna/Node.kt
@@ -68,18 +68,18 @@ open class Node(var circuit: Circuit) : IDetail, Set() {
 }
 
 /**
- * A Node subclass for representing [Circuit.ground], with a higher [mergePrecedence], always [potential] 0V and [index] -1 (not assigned).
+ * A Node subclass for representing [Circuit.ground], with a higher mergePrecedence, always [potential] 0V and [index] -1 (not assigned).
  *
  * The current recommended test for this special case is `node is GroundNode`.
  */
 class GroundNode(circuit: Circuit) : Node(circuit) {
     override var potential: Double
         get() = 0.0
-        set(value) {}
+        set(_) {}
 
     override var index: Int
         get() = -1
-        set(value) {}
+        set(_) {}
 
     override val isGround = true
 }

--- a/core/src/main/kotlin/org/eln2/sim/electrical/mna/VSource.kt
+++ b/core/src/main/kotlin/org/eln2/sim/electrical/mna/VSource.kt
@@ -34,7 +34,7 @@ class VSource(var circuit: Circuit) : IDetail {
      * This property is only a guess, updated by [stamp] and [change], assuming those are used correctly. It cannot be publicly assigned; use [stamp] and [change] instead. A typical intra-step invocation might be `vs.change(newPotential - vs.potential)`, but this is only safe to do within certain contexts and thus not implemented here by default.
      */
     var potential: Double = 0.0
-        protected set
+        internal set
 
     override fun detail(): String {
         return "[$name ${this::class.simpleName}@${System.identityHashCode(this).toString(16)} ${current}A]"

--- a/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/Capacitor.kt
+++ b/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/Capacitor.kt
@@ -39,7 +39,7 @@ open class Capacitor : Port() {
     /**
      * The "equivalent resistance" of the Norton system, in Ohms.
      */
-    val eqR: Double
+    private val eqR: Double
         get() = ts / capacitance
 
     /**

--- a/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/Component.kt
+++ b/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/Component.kt
@@ -90,6 +90,7 @@ abstract class Component : IDetail {
      * Component implementations should index this list and avoid storing references anywhere else. The owning
     Circuit holds all Nodes it grants weakly, so taking other references will result in a memory leak.
      */
+    @Suppress("LeakingThis") // Safe in a single threaded setting, apparently.
     var nodes: MutableList<NodeRef> = ArrayList(nodeCount)
 
     /**
@@ -97,12 +98,13 @@ abstract class Component : IDetail {
      *
      * Like [nodes], these are only weakly held by the [Circuit].
      */
+    @Suppress("LeakingThis") // Safe in a single threaded setting, apparently.
     var vsources: MutableList<VSource> = ArrayList(vsCount)
 
     /**
      * Get a [Node] by index (the one underlying the [NodeRef]).
      */
-    inline fun node(i: Int) = nodes[i].node
+    fun node(i: Int) = nodes[i].node
 
     /** Connects two Components--makes nodes[nidx] the SAME Node as to.nodes[tidx], respecting precedence.
 
@@ -166,7 +168,7 @@ abstract class Port : Component() {
     /**
      * Get the positive [Node].
      *
-     * By arbitrary convention, for compatibility with the [Falstad] circuit format, this is the second node.
+     * By arbitrary convention, for compatibility with the Falstad circuit format, this is the second node.
      */
     open val pos: Node
         get() = node(1)
@@ -174,7 +176,7 @@ abstract class Port : Component() {
     /**
      * Get the negative [Node].
      *
-     * This is arbitrarily the first Node, for [Falstad] compatibility.
+     * This is arbitrarily the first Node, for Falstad compatibility.
      */
     open val neg: Node
         get() = node(0)

--- a/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/Diode.kt
+++ b/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/Diode.kt
@@ -19,11 +19,13 @@ class IdealDiode : Resistor() {
     /**
      * The resistance this diode should have when forward-biased; ideally zero, but this will cause the MNA matrix to be ill-formed.
      */
+    @Suppress("MemberVisibilityCanBePrivate")
     var minimumResistance = 1e-3
 
     /**
      * The resistance this diode should have when reverse-biased; may be infinite, but this can cause component float, so it is just a large value by default.
      */
+    @Suppress("MemberVisibilityCanBePrivate")
     var maximumResistance = 1e10
 
     override fun simStep() {
@@ -92,11 +94,13 @@ data class DiodeData(
         /**
          * Boltzmann's constant, relating energy and temperature.
          */
+        @Suppress("MemberVisibilityCanBePrivate")
         const val boltzmann = 1.380649e-23 // J/K
 
         /**
          * The elementary charge of one electron in Coulombs.
          */
+        @Suppress("MemberVisibilityCanBePrivate")
         const val elemcharge = 1.602176634e-19 // Q
 
         /**
@@ -112,25 +116,26 @@ data class DiodeData(
          *
          * This parameter generally scales all other diode parameters, including the Zener band gap (below).
          */
-        inline fun thermalVoltage(temp: Double) = temp * boltzmann / elemcharge
+        fun thermalVoltage(temp: Double) = temp * boltzmann / elemcharge
 
         /**
          * Get the Zener coefficient at the given [temp] in Kelvin.
          *
          * This is the reciprocal of the thermal voltage.
          */
-        inline fun zenerCoefficient(temp: Double) = 1.0 / thermalVoltage(temp)
+        fun zenerCoefficient(temp: Double) = 1.0 / thermalVoltage(temp)
     }
 
     /**
      * Determine if this is a Zener-model diode (having nonzero breakdown voltage).
      */
+    @Suppress("unused")
     val isZener: Boolean get() = breakdownVoltage != 0.0
 
     /**
      * Get the "voltage scale" (the emission coefficient times the thermal voltage) at the given [temp] in Kelvin.
      */
-    fun voltageScaleAt(temp: Double) = emissionCoef * thermalVoltage(temp)
+    private fun voltageScaleAt(temp: Double) = emissionCoef * thermalVoltage(temp)
 
     /**
      * Get the "diode coefficient" (reciprocal of the "voltage scale") at the given [temp] in Kelvin.
@@ -140,12 +145,13 @@ data class DiodeData(
     /**
      * Get the forward voltage drop at the given [temp] in Kelvin.
      */
+    @Suppress("unused")
     fun fwDropAt(temp: Double) = ln(1.0 / satCurrent + 1.0) * voltageScaleAt(temp)
 
     /**
      * Get the "critical voltage" for the [temp] in Kelvin.
      */
-    fun voltageCriticalAt(temp: Double): Double {
+    private fun voltageCriticalAt(temp: Double): Double {
         val voltageThermalScaled = voltageScaleAt(temp)
         return voltageThermalScaled * ln(voltageThermalScaled / (sqrt2 * satCurrent))
     }
@@ -155,7 +161,7 @@ data class DiodeData(
      *
      * Despite being a reverse bias, this returns a positive value.
      */
-    fun voltageCriticalZenerAt(temp: Double): Double {
+    private fun voltageCriticalZenerAt(temp: Double): Double {
         val voltageThermal = thermalVoltage(temp)
         return voltageThermal * ln(voltageThermal / (sqrt2 * satCurrent))
     }
@@ -228,10 +234,10 @@ data class DiodeData(
  *
  * This is certainly not as computationally efficient as the [IdealDiode], but it is a vastly superior model. The cost is that it may take several substeps to converge (as a non-linear component), but the convergence should be exponential nonetheless.
  */
-class RealisticDiode(var model: DiodeData) : Resistor() {
-    var temp = 300.0
+class RealisticDiode(private var model: DiodeData) : Resistor() {
+    private var temp = 300.0
 
-    var lastPotential = 0.0
+    private var lastPotential = 0.0
 
     override var current: Double = 0.0
         set(value) {

--- a/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/Inductor.kt
+++ b/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/Inductor.kt
@@ -27,7 +27,7 @@ open class Inductor : Port() {
     /**
      * The "equivalent resistance" of the Norton system, in Ohms.
      */
-    val eqR: Double
+    private val eqR: Double
         get() = l / ts
 
     /**
@@ -43,6 +43,7 @@ open class Inductor : Port() {
     /**
      * The current amount of magnetic flux, in Webers (Volt * second), based on the instantaneous derivative of the current in Amperes.
      */
+    @Suppress("MemberVisibilityCanBePrivate")
     var phi: Double = 0.0
 
     override fun detail(): String {

--- a/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/Resistor.kt
+++ b/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/Resistor.kt
@@ -36,7 +36,8 @@ open class Resistor : Port() {
     /**
      * Returns the power dissipated by this resistor, as a function of its current and potential, in Watts.
      */
-    open val p: Double
+    @Suppress("unused")
+    open val power: Double
         get() = current * potential
 
     override fun detail(): String {

--- a/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/VoltageSource.kt
+++ b/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/VoltageSource.kt
@@ -29,12 +29,6 @@ class VoltageSource : Port() {
     val current: Double
         get() = if (isInCircuit) vsources[0].current else 0.0
 
-    /**
-     * The current through this source, as a result of the simulation step.
-     */
-    val i: Double
-        get() = if (isInCircuit) vsources[0].current else 0.0
-
     override fun detail(): String {
         return "[voltage source u:$potential]"
     }

--- a/core/src/test/kotlin/org/eln2/sim/electrical/mna/CircuitTest.kt
+++ b/core/src/test/kotlin/org/eln2/sim/electrical/mna/CircuitTest.kt
@@ -207,6 +207,6 @@ internal class CircuitTest {
             println("main_1: node ${node.get()} index ${node.get()?.index} potential ${node.get()?.potential}")
         }
 
-        println("main_1: vs current: ${vs.i}\nmain_1: r1 current: ${r1.current}")
+        println("main_1: vs current: ${vs.current}\nmain_1: r1 current: ${r1.current}")
     }
 }

--- a/core/src/test/kotlin/org/eln2/sim/electrical/mna/ComponentTest.kt
+++ b/core/src/test/kotlin/org/eln2/sim/electrical/mna/ComponentTest.kt
@@ -1,3 +1,0 @@
-package org.eln2.sim.electrical.mna
-
-internal class ComponentTest

--- a/core/src/test/kotlin/org/eln2/sim/electrical/mna/IProcessTest.kt
+++ b/core/src/test/kotlin/org/eln2/sim/electrical/mna/IProcessTest.kt
@@ -5,15 +5,15 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 internal class IProcessTest : IProcess {
-    private var time_run: Double = 0.0
+    private var timeRun: Double = 0.0
 
     @Test
     fun iProcessTest() {
         repeat(20) { process(0.05); } // Run the simulation 20 times for 50 ms each.
-        Assertions.assertEquals(time_run, 1.0, 0.001) // Total time elapsed should be one second.
+        Assertions.assertEquals(timeRun, 1.0, 0.001) // Total time elapsed should be one second.
     }
 
     override fun process(dt: Double) {
-        time_run += dt
+        timeRun += dt
     }
 }


### PR DESCRIPTION
There were a handful of lints that I fixed through much of the code.

It makes it much easier to understand `Circuit` as well if we have the internal stuff marked `internal`.

I also corrected some nested `it` situations, which often lead to code errors.