### PR TITLE
Change to a Pin-based connection model.

### DIFF
--- a/core/src/main/kotlin/org/eln2/data/DisjointSet.kt
+++ b/core/src/main/kotlin/org/eln2/data/DisjointSet.kt
@@ -11,11 +11,12 @@ package org.eln2.data
  *
  * Typical use case is as follows:
  *
- * 1. Choose your method above; for the former, the Set object is `this`; for the latter, substitute your field.
- * 2. Unify Sets by calling [unite].
- * 3. Determine if two Sets are in the same component by testing their [representative] for equality.
+ * 1. Choose your method above; for the former, the DisjointSet object is `this`; for the latter, substitute your field.
+ * 2. Unify DisjointSets by calling [unite].
+ * 3. Determine if two DisjointSets are in the same component by testing their [representative] for equality.
+ * 4. Optionally, mutate the data on a DisjointSet subclass' representative, knowing that the mutations are visible from all DisjointSets with the same representative.
  *
- * In the case of inheriting Set, you can also store data on the representative. Note that it is difficult to control which instance will ultimately *be* the representative; in the cases where it can't be avoided, [priority] can be used, but this is advisable only as a last resort (since it reduces the optimality of this algorithm).
+ * Note that it is difficult to control which instance will ultimately *be* the representative; in the cases where it can't be avoided, [priority] can be used, but this is advisable only as a last resort (since it reduces the optimality of this algorithm).
 */
 open class DisjointSet {
 
@@ -41,7 +42,7 @@ open class DisjointSet {
     open val priority: Int = 0
 
     /**
-     * Find the representative of this set.
+     * Find the representative of this disjoint set.
      *
      * This instance is the same as all other instances that have been [unite]d, transitively, with this one.
      *
@@ -59,13 +60,13 @@ open class DisjointSet {
         }
 
     /**
-     * Unite this instance with another instance of Set.
+     * Unite this instance with another instance of DisjointSet.
      *
      * After this is done, both this and [other] will have the same [representative] as each other (and as all other Sets with which they were previously united).
      *
      * This is implemented using the "by size" merge algorithm, adjusted for [priority].
      */
-    fun unite(other: DisjointSet) {
+    open fun unite(other: DisjointSet) {
         val trep = representative
         val orep = other.representative
         if (trep == orep) return

--- a/core/src/main/kotlin/org/eln2/data/MultiMap.kt
+++ b/core/src/main/kotlin/org/eln2/data/MultiMap.kt
@@ -156,6 +156,8 @@ class MutableSetMapMultiMap<K, V>(iter: Iterator<Pair<K, V>>) : MutableMultiMap<
     /** This implementation is O(keyMappingSize). */
     override val entriesSize: Int
         get() = map.entries.map { (_, vs) -> vs.size }.sum()
+
+    override fun toString() = map.toString()
 }
 
 /**

--- a/core/src/main/kotlin/org/eln2/debug/MatrixPrint.kt
+++ b/core/src/main/kotlin/org/eln2/debug/MatrixPrint.kt
@@ -14,8 +14,8 @@ import org.eln2.sim.electrical.mna.Circuit
  * @param headerfooter If you want a footer
  * @return matrix output
  */
-fun matrixFormat(matrix: RealMatrix, headerfooter: Boolean = true): String {
-    if (matrix.data.isEmpty()) return ""
+fun matrixFormat(matrix: RealMatrix?, headerfooter: Boolean = true): String {
+    if(matrix == null || matrix.data.isEmpty()) return ""
     val rows = matrix.rowDimension
     val columns = matrix.columnDimension
     val singleRow = rows <= 1
@@ -69,26 +69,14 @@ fun matrixFormat(matrix: RealMatrix, headerfooter: Boolean = true): String {
 }
 
 /**
- * knownsFormat: Prints out the z matrix for the MNA
- *
- * @param knowns The z matrix
- * @param headerfooter If you want a footer
- * @return matrix output
+ * Format a column vector into a string.
  */
-fun knownsFormat(knowns: RealVector, headerfooter: Boolean = true): String {
-    return matrixFormat(MatrixUtils.createColumnRealMatrix(knowns.toArray()), headerfooter)
-}
-
-/**
- * unknownsFormat: Prints out the x matrix for the MNA
- *
- * @param unknowns The x matrix
- * @param headerfooter If you want a footer
- * @return matrix output
- */
-fun unknownsFormat(unknowns: RealVector?, headerfooter: Boolean = true): String {
-    if(unknowns == null) return ""
-    return matrixFormat(MatrixUtils.createColumnRealMatrix(unknowns.toArray()), headerfooter)
+fun vectorFormat(vector: RealVector?, headerfooter: Boolean = true): String {
+    return matrixFormat(
+        vector.let {
+            if (it == null) null else MatrixUtils.createColumnRealMatrix(it.toArray())
+        }, headerfooter
+    )
 }
 
 /**
@@ -101,7 +89,7 @@ fun unknownsFormat(unknowns: RealVector?, headerfooter: Boolean = true): String 
  */
 fun mnaFormatNoUnknowns(matrix: RealMatrix, knowns: RealVector, color: Boolean = true): String {
     val mftLines = matrixFormat(matrix, false).split("\n").filter { it.isNotBlank() }
-    val kftLines = knownsFormat(knowns, false).split("\n").filter { it.isNotBlank() }
+    val kftLines = vectorFormat(knowns, false).split("\n").filter { it.isNotBlank() }
     val biggest = kotlin.math.max(mftLines.size, kftLines.size)
     val midpoint = biggest / 2
     val sb = StringBuilder()
@@ -147,8 +135,8 @@ fun mnaFormat(circuit: Circuit, color: Boolean = true): String {
 fun mnaFormat(matrix: RealMatrix, knowns: RealVector, unknowns: RealVector?, color: Boolean = true): String {
     if (unknowns == null) return mnaFormatNoUnknowns(matrix, knowns, color)
     val mftLines = matrixFormat(matrix, false).split("\n").filter { it.isNotBlank() }
-    val kftLines = knownsFormat(knowns, false).split("\n").filter { it.isNotBlank() }
-    val uftLines = unknownsFormat(unknowns, false).split("\n").filter { it.isNotBlank() }
+    val kftLines = vectorFormat(knowns, false).split("\n").filter { it.isNotBlank() }
+    val uftLines = vectorFormat(unknowns, false).split("\n").filter { it.isNotBlank() }
     val biggest = kotlin.math.max(mftLines.size, kotlin.math.max(kftLines.size, uftLines.size))
     val midpoint = biggest / 2
     val even = biggest % 2 == 0
@@ -205,7 +193,7 @@ fun mnaIntelligentFormat(circuit: Circuit): String {
  * @param matrix The A Matrix
  */
 @Suppress("unused")
-fun matrixPrint(matrix: RealMatrix) {
+fun matrixPrintln(matrix: RealMatrix) {
     print(matrixFormat(matrix, true))
 }
 
@@ -214,8 +202,8 @@ fun matrixPrint(matrix: RealMatrix) {
  * @param knowns The Z Matrix
  */
 @Suppress("unused")
-fun knownsPrint(knowns: RealVector) {
-    print(knownsFormat(knowns, true))
+fun knownsPrintln(knowns: RealVector) {
+    print(vectorFormat(knowns, true))
 }
 
 /**
@@ -223,8 +211,8 @@ fun knownsPrint(knowns: RealVector) {
  * @param unknowns The X Matrix
  */
 @Suppress("unused")
-fun unknownsPrint(unknowns: RealVector?) {
-    if (unknowns != null) println(unknownsFormat(unknowns, true))
+fun unknownsPrintln(unknowns: RealVector?) {
+    if (unknowns != null) println(vectorFormat(unknowns, true))
 }
 
 /**
@@ -235,7 +223,7 @@ fun unknownsPrint(unknowns: RealVector?) {
  * @param color Whether to print in color or not
  */
 @Suppress("unused")
-fun mnaPrint(matrix: RealMatrix, knowns: RealVector, unknowns: RealVector?, color: Boolean = true) {
+fun mnaPrintln(matrix: RealMatrix, knowns: RealVector, unknowns: RealVector?, color: Boolean = true) {
     print(mnaFormat(matrix, knowns, unknowns, color))
 }
 
@@ -244,7 +232,7 @@ fun mnaPrint(matrix: RealMatrix, knowns: RealVector, unknowns: RealVector?, colo
  * @param circuit The circuit
  */
 @Suppress("unused")
-fun mnaPrint(circuit: Circuit, color: Boolean = true) {
+fun mnaPrintln(circuit: Circuit, color: Boolean = true) {
     print(mnaFormat(circuit, color))
 }
 
@@ -253,6 +241,6 @@ fun mnaPrint(circuit: Circuit, color: Boolean = true) {
  * @param circuit The circuit
  */
 @Suppress("unused")
-fun mnaIntelligentPrint(circuit: Circuit) {
+fun mnaIntelligentPrintln(circuit: Circuit) {
     print(mnaIntelligentFormat(circuit))
 }

--- a/core/src/main/kotlin/org/eln2/parsers/falstad/Falstad.kt
+++ b/core/src/main/kotlin/org/eln2/parsers/falstad/Falstad.kt
@@ -382,7 +382,7 @@ class Falstad(val source: String) {
             if (pinset.isNotEmpty()) {
                 // Only need to connect 1; the disjoint PosSets are merged right now
                 val pr = pinset.iterator().next()
-                pr.component.connect(pr.pinidx, circuit.ground)
+                pr.component.ground(pr.pinidx)
             }
         }
 
@@ -394,7 +394,7 @@ class Falstad(val source: String) {
             for (comp in circuit.components) {
                 if (comp is VoltageSource) {
                     dprintln("F.<init>: floating: ground $comp pin 1 (node ${comp.node(1)}")
-                    comp.connect(1, circuit.ground)
+                    comp.ground(1)
                     found = true
                     break
                 }
@@ -441,15 +441,15 @@ class Falstad(val source: String) {
 
                 dprintln("outputs:")
                 f.outputNodes.withIndex().forEach { nodeidx ->
-                    println("${nodeidx.index}: ${nodeidx.value.potential}V @${nodeidx.value.index}")
+                    println("${nodeidx.index}: ${nodeidx.value?.potential}V @${nodeidx.value?.index}")
                 }
             }
 
             val on = f.outputNodes
-            println("#T\t${on.indices.map { i -> "O${i + 1}" }.joinToString("\t")}")
+            println("#T\t${on.indices.joinToString("\t") { i -> "O${i + 1}" }}")
             (1..steps).forEach { step ->
                 if (!f.circuit.step(f.nominalTimestep)) error("step error (singularity?)")
-                println("${step * f.nominalTimestep}\t${on.map { node -> node.potential }.joinToString("\t")}")
+                println("${step * f.nominalTimestep}\t${on.joinToString("\t") { node -> node?.potential.toString() }}")
             }
 
             // FileOutputStream("falstad.dot").bufferedWriter().also {

--- a/core/src/main/kotlin/org/eln2/parsers/falstad/components/generic/OutputProbe.kt
+++ b/core/src/main/kotlin/org/eln2/parsers/falstad/components/generic/OutputProbe.kt
@@ -20,7 +20,7 @@ class OutputProbe : IComponentConstructor {
         val r = Resistor()
         r.resistance = HIGH_IMPEDANCE
         ccd.circuit.add(r)
-        r.connect(1, ccd.circuit.ground)
+        r.ground(1)
 
         val pp = (ccd.falstad.getPin(ccd.pos).representative as PosSet)
         val pr = PinRef(r, 0)

--- a/core/src/main/kotlin/org/eln2/parsers/falstad/components/sources/VoltageRailConstructor.kt
+++ b/core/src/main/kotlin/org/eln2/parsers/falstad/components/sources/VoltageRailConstructor.kt
@@ -15,7 +15,7 @@ class VoltageRailConstructor : PoleConstructor() {
     override fun configure(ccd: CCData, cmp: Component) {
         val v = (cmp as VoltageSource)
         v.potential = ccd.data[2].toDouble() + ccd.data[3].toDouble()
-        v.connect(1, ccd.circuit.ground) // nidx 1 should be neg
+        v.ground(1) // nidx 1 should be neg
         ccd.pins = 1 // After the above--there are two pins, but the second is dropped
         ccd.falstad.floating = false
     }

--- a/core/src/main/kotlin/org/eln2/sim/electrical/mna/Circuit.kt
+++ b/core/src/main/kotlin/org/eln2/sim/electrical/mna/Circuit.kt
@@ -12,8 +12,6 @@ import java.lang.ref.WeakReference
 import java.util.*
 import kotlin.collections.ArrayList
 
-class PinDebugQueueEntry(val pin: Pin, val lastSibling: Boolean)
-
 /**
  * The default format for debug matrix printouts from Circuits.
  */
@@ -399,6 +397,8 @@ class Circuit {
                 }
             }
         }
+    
+    private class PinDebugQueueEntry(val pin: Pin, val lastSibling: Boolean)
 
     /**
      * Build the [matrix] and the [nodes] and [voltageSources], imparting each with indices.

--- a/core/src/main/kotlin/org/eln2/sim/electrical/mna/Circuit.kt
+++ b/core/src/main/kotlin/org/eln2/sim/electrical/mna/Circuit.kt
@@ -9,7 +9,7 @@ import org.eln2.debug.dprintln
 import org.eln2.sim.IProcess
 import org.eln2.sim.electrical.mna.component.*
 import java.lang.ref.WeakReference
-import java.util.*
+import java.util.WeakHashMap
 import kotlin.collections.ArrayList
 
 /**

--- a/core/src/main/kotlin/org/eln2/sim/electrical/mna/Circuit.kt
+++ b/core/src/main/kotlin/org/eln2/sim/electrical/mna/Circuit.kt
@@ -1,12 +1,18 @@
 package org.eln2.sim.electrical.mna
 
 import org.apache.commons.math3.linear.*
+import org.eln2.data.MutableMultiMap
+import org.eln2.data.mutableMultiMapOf
+import org.eln2.debug.DEBUG
 import org.eln2.debug.dprint
 import org.eln2.debug.dprintln
 import org.eln2.sim.IProcess
 import org.eln2.sim.electrical.mna.component.*
 import java.lang.ref.WeakReference
-import java.util.WeakHashMap
+import java.util.*
+import kotlin.collections.ArrayList
+
+class PinDebugQueueEntry(val pin: Pin, val lastSibling: Boolean)
 
 /**
  * The default format for debug matrix printouts from Circuits.
@@ -143,13 +149,6 @@ class Circuit {
      * It should be an invariant that `this.components.all { it.circuit == this }`.
      */
     val components = mutableListOf<Component>()
-
-    /**
-     * A map from [Node] to the owning [Component].
-     *
-     * This does not include the [ground] NodeRef owned by the Circuit.
-     */
-    private val compNodeMap = WeakHashMap<Node, Component>()
 
     /**
      * A map from [VSource] to the owning [Component].
@@ -298,6 +297,7 @@ class Circuit {
      * This calls [stampMatrix] and [stampKnown] internally. It should only ever be called from [Component.stamp].
      */
     internal fun stampVoltageSource(pos: Int, neg: Int, num: Int, v: Double) {
+        if(num < 0) return  // Don't accidentally stamp conductances
         val vs = num + nodes.size
         stampMatrix(vs, neg, -1.0)
         stampMatrix(vs, pos, 1.0)
@@ -341,10 +341,8 @@ class Circuit {
         componentsChanged = true
         // This is the ONLY place where this should be set.
         comp.circuit = this
-        for (i in 0 until comp.nodeCount) {
-            val n = Node(this)
-            compNodeMap[n] = comp
-            comp.nodes.add(n)
+        for (i in 0 until comp.pinCount) {
+            comp.pins.add(Pin())
         }
         for (i in 0 until comp.vsCount) {
             val vs = VSource(this)
@@ -353,7 +351,7 @@ class Circuit {
         }
         comp.added()
 
-        dprintln("C.a: $comp has nodes ${comp.nodes} vs ${comp.vsources}")
+        dprintln("C.a: $comp has pins ${comp.pins} vs ${comp.vsources}")
         return comp
     }
 
@@ -376,8 +374,7 @@ class Circuit {
     fun remove(comp: Component): Boolean {
         return if (components.remove(comp)) {
             comp.removed()
-            comp.nodes.forEach { compNodeMap.remove(it) }
-            comp.nodes.clear()
+            comp.pins.clear()
             comp.vsources.forEach { compVsMap.remove(it) }
             comp.vsources.clear()
             // This is the ONLY place where this should be cleared.
@@ -397,8 +394,8 @@ class Circuit {
         get() {
             if (componentsChanged || connectivityChanged) buildMatrix()
             return !components.any {component ->
-                component.nodes.any {
-                    it.representative == ground
+                component.pins.any {
+                    it.node == ground
                 }
             }
         }
@@ -416,19 +413,87 @@ class Circuit {
     // a matrix of appropriate size.
     internal fun buildMatrix() {
         dprintln("C.bM")
-        val nodeSet: MutableSet<Node> = mutableSetOf()
+        val pinSet: MutableSet<Pin> = mutableSetOf()
         val voltageSourceSet: MutableSet<VSource> = mutableSetOf()
 
         components.forEach {component ->
-            dprintln("C.bM: component $component nodes ${component.nodes}")
-            nodeSet.addAll(component.nodes.map { it.representative as Node }.filter { it != ground })
+            dprintln("C.bM: component $component pinreps ${component.pins.map { it.representative as Pin }}")
+            pinSet.addAll(component.pins.map { it.representative as Pin })
             voltageSourceSet.addAll(component.vsources)
         }
 
-        nodes = nodeSet.map { WeakReference(it) }.toList()
-        voltageSources = voltageSourceSet.map { WeakReference(it) }.toList()
+        dprintln("C.bM: pinreps $pinSet")
+        
+        val newNodes = ArrayList<WeakReference<Node>>(pinSet.size)
+        var i = 0
+        for(p in pinSet) {
+            if(p.node == null) {
+                p.node = Node(this)
+            }
+            if(p.node != ground) {
+                p.node!!.index = i++
+                newNodes.add(WeakReference(p.node))
+            }
+        }
+        nodes = newNodes
 
-        for ((i, n) in nodes.withIndex()) n.get()!!.index = i
+        if(DEBUG) {
+            val pinForest: MutableMultiMap<Pin, Pin> = mutableMultiMapOf()
+            val pinMapping: MutableMap<Pin, Pair<Component, Int>> = mutableMapOf()
+            
+            components.forEach { comp ->
+                println("C.bM: pins for $comp:")
+                comp.pins.withIndex().forEach { (idx, pin) ->
+                    println("C.bM: $idx: $pin")
+                    pinForest[pin.parent as Pin] = pin
+                    pinMapping[pin] = Pair(comp, idx)
+                }
+            }
+
+            println("C.bM: pinForest=$pinForest pinMapping=$pinMapping")
+
+            println("C.bM: pin forest:")
+            
+            val roots: MutableSet<Pin> = pinForest.keys.filter { it in pinForest[it] }.toMutableSet()
+            val unvisited: MutableSet<Pin> = pinMapping.keys.toMutableSet()
+            val queue: MutableList<PinDebugQueueEntry> = mutableListOf()
+
+            while(unvisited.isNotEmpty()) {
+                if(queue.isEmpty()) {
+                    if(roots.isEmpty()) {
+                        println("C.bM: ERROR: no roots and unvisited nonempty: $unvisited")
+                        break
+                    }
+
+                    println()
+                    val root = roots.iterator().next()
+                    roots.remove(root)
+                    queue.add(PinDebugQueueEntry(root, true))
+                    print("root: ")
+                }
+                
+                val front = queue.removeAt(0)
+                unvisited.remove(front.pin)
+                val children = pinForest[front.pin].filter { it in unvisited }
+                children.withIndex().forEach { (idx, pin) ->
+                    queue.add(PinDebugQueueEntry(pin,
+                        front.lastSibling && idx == children.size - 1
+                    ))
+                }
+                
+                print("${front.pin} (${children.size} children)")
+                val owner = pinMapping[front.pin]
+                if(owner != null) {
+                    val (comp, idx) = owner
+                    print(" (owner $comp pin $idx)")
+                } else {
+                    print(" (no owner?)")
+                }
+                print(if(front.lastSibling) "\n" else "\t")
+            }
+        }
+
+        voltageSources = voltageSourceSet.map { WeakReference(it) }.toList()
         for ((i, v) in voltageSources.withIndex()) v.get()!!.index = i
 
         dprintln("C.bM: n ${nodes.map { it.get()?.detail() }} vs ${voltageSources.map { it.get()?.detail() }}")
@@ -585,15 +650,15 @@ class Circuit {
         sb.append("\n\t// Connections\n")
         components.forEach { cmp ->
             // This may be broken. It used to use .withIndex() but that resulted in too many possible results. We don't have tests for this, so wheee!
-            cmp.nodes.forEach {
-                val port = when (it.index) {
+            cmp.pins.forEach {
+                val port = when (it.node?.index) {
                     0 -> ":w"
                     1 -> ":e"
                     else -> ""
                 }
                 val node = it.representative as Node
                 sb.append("\t\"c${System.identityHashCode(cmp)}\"$port -- \"${if(node.isGround) "ground" else "n${node.index}"}\" [shape=box ")
-                when (it.index) {
+                when (it.node?.index) {
                     0 -> sb.append("color=red")
                     1 -> sb.append("color=blue")
                     else -> sb.append("color=gray")

--- a/core/src/main/kotlin/org/eln2/sim/electrical/mna/Node.kt
+++ b/core/src/main/kotlin/org/eln2/sim/electrical/mna/Node.kt
@@ -11,6 +11,13 @@ import org.eln2.data.DisjointSet
  */
 open class Node(var circuit: Circuit) : IDetail, DisjointSet() {
     companion object {
+        /**
+         * Determine which of two (nullable) Nodes should subsume the other when the two are about to be merged.
+         *
+         * This respects [priority], and tries to return the distinguished one, if any, which is not null.
+         *
+         * It also tries to propagate [name] as best it can.
+         */
         fun mergeData(a: Node?, b: Node?): Node? {
             val res = when(Pair(a == null, b == null)) {
                 Pair(true, true) -> null

--- a/core/src/main/kotlin/org/eln2/sim/electrical/mna/Node.kt
+++ b/core/src/main/kotlin/org/eln2/sim/electrical/mna/Node.kt
@@ -5,11 +5,30 @@ import org.eln2.sim.electrical.mna.component.Component
 import org.eln2.data.DisjointSet
 
 /**
- * A "node", in MNA; the non-resistive connections between [Component]s.
+ * A "node", in MNA; the non-resistive connections between [Component]s. All [Pin]s which are connected share a single instance of Node.
  *
  * Aside from identifying [Component]s' connections, the Nodes' potentials (relative to [Circuit.ground]) are computed as a result of the MNA algorithm.
  */
 open class Node(var circuit: Circuit) : IDetail, DisjointSet() {
+    companion object {
+        fun mergeData(a: Node?, b: Node?): Node? {
+            val res = when(Pair(a == null, b == null)) {
+                Pair(true, true) -> null
+                Pair(true, false) -> b
+                Pair(false, true) -> a
+                Pair(false, false) -> {
+                    // Forgive me some non-null assertions; the compiler cannot see that these variables will not be
+                    // null in this branch by very virtue of the test, but we know it to be true :)
+                    val (higher, lower) = if(a!!.priority > b!!.priority) Pair(a, b) else Pair(b, a)
+                    if(lower.nameSet) higher.name = lower.name
+                    higher
+                }
+                else -> error("unreachable")  // TODO: Any better function for this?
+            }
+            dprintln("N.mD: $a, $b => $res")
+            return res
+        }
+    }
     /**
      * The potential of this node, in Volts, relative to ground (as defined by the [Circuit]); an output of the simulation.
      */
@@ -55,7 +74,7 @@ open class Node(var circuit: Circuit) : IDetail, DisjointSet() {
     }
 
     override fun detail(): String {
-        return "[$name ${this::class.simpleName}@${System.identityHashCode(this).toString(16)} ${potential}V]"
+        return "[$name ${this::class.simpleName}@${System.identityHashCode(this).toString(16)} ${potential}V @$index]"
     }
 
     override fun toString() = detail()

--- a/core/src/main/kotlin/org/eln2/sim/electrical/mna/VSource.kt
+++ b/core/src/main/kotlin/org/eln2/sim/electrical/mna/VSource.kt
@@ -62,6 +62,7 @@ class VSource(var circuit: Circuit) : IDetail {
      * This also adds [dv] to [potential].
      */
     fun change(dv: Double) {
+        if(index < 0) return
         circuit.stampVoltageChange(index, dv)
         potential += dv
     }

--- a/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/Capacitor.kt
+++ b/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/Capacitor.kt
@@ -7,9 +7,9 @@ import org.eln2.debug.dprintln
  *
  * Capacitors are defined by a characteristic of "mutual capacitance", which (for two separate conductors sharing an E-field) is defined as the charge per unit potential. Since current is the derivative of charge, current in any one direction causes an increase in potential across the capacitor, often referred to as "charging" when the current is of the same sign as the prevailing potential, and "discharging" when it is opposite.
  *
- * Thus, as an implementation detail, one of the two out-of-phase components must be stored--either the present charge, or the ideal potential. This implementation stores the ideal potential as [idealU].
+ * Thus, as an implementation detail, one of the two out-of-phase components must be stored--either the present charge, or the ideal potential. This implementation stores the ideal potential as [idealU]. The other can be calculated directly using [capacitance].
  *
- * This reactive component is simulated using a Norton system, as designed by Falstad. It is not "non-linear", however, and does not need any substeps to compute. It does, however, need to know the timescale of the simulation steps.
+ * This reactive component is simulated using a Norton system, as designed by Falstad. It is not "non-linear", however, and does not need any substeps to compute. It does, however, need to know the timescale of the simulation steps. Changing the simulation timestep dynamically can cause performance problems, however, and is best avoided.
  */
 open class Capacitor : Port() {
     override var name: String = "c"
@@ -39,9 +39,9 @@ open class Capacitor : Port() {
      */
     var ts: Double = 0.05  // A safe default
         set(value) {
-            unstamp()
+            if(isInCircuit) unstamp()
             field = value
-            stamp()
+            if(isInCircuit) stamp()
         }
 
     /**
@@ -51,9 +51,17 @@ open class Capacitor : Port() {
         get() = ts / capacitance
 
     /**
+     * Current across the device (as a whole), in Amps. See [i] for the current sourced by the Norton system.
+     */
+    val current: Double
+        get() = if (eqR > 0) {
+            potential / eqR + i
+        } else 0.0
+
+    /**
      * The current, in Amperes, presently sourced by this Norton system.
      */
-    internal var current: Double = 0.0
+    internal var i: Double = 0.0
         set(value) {
             if (isInCircuit && pos != null && neg != null)
                 circuit!!.stampCurrentSource(pos!!.index, neg!!.index, value - field)
@@ -66,13 +74,13 @@ open class Capacitor : Port() {
     var idealU: Double = 0.0
 
     override fun detail(): String {
-        return "[capacitor $name: ${potential}v, ${current}A, ${capacitance}F, ${energy}J]"
+        return "[capacitor $name: ${potential}v, ${i}A, ${capacitance}F, ${energy}J]"
     }
 
     override fun preStep(dt: Double) {
-        if(ts != dt) ts = dt  // May cause conductivity change/matrix solve step
-        current = -idealU / eqR
-        dprintln("C.preS: i=$current eqR=$eqR idealU=$idealU")
+        if(ts != dt) ts = dt  // May cause conductivity change/matrix solve step--avoid this if possible
+        i = -idealU / eqR
+        dprintln("C.preS: i=$i eqR=$eqR idealU=$idealU")
     }
 
 

--- a/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/CurrentSource.kt
+++ b/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/CurrentSource.kt
@@ -15,8 +15,8 @@ class CurrentSource : Port() {
      */
     var current: Double = 0.0
         set(value) {
-            if (isInCircuit)
-                circuit!!.stampCurrentSource(pos.index, neg.index, value - field)
+            if (isInCircuit && pos != null && neg != null)
+                circuit!!.stampCurrentSource(pos!!.index, neg!!.index, value - field)
             field = value
         }
 
@@ -25,7 +25,6 @@ class CurrentSource : Port() {
     }
 
     override fun stamp() {
-        if (!isInCircuit) return
-        circuit!!.stampCurrentSource(pos.index, neg.index, current)
+        circuit!!.stampCurrentSource(pos!!.index, neg!!.index, current)
     }
 }

--- a/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/Diode.kt
+++ b/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/Diode.kt
@@ -250,8 +250,8 @@ class RealisticDiode(private var model: DiodeData) : Resistor() {
 
     override var current: Double = 0.0
         set(value) {
-            if (isInCircuit)
-                circuit!!.stampCurrentSource(pos.index, neg.index, value - field)
+            if (isInCircuit && pos != null && neg != null)
+                circuit!!.stampCurrentSource(pos!!.index, neg!!.index, value - field)
             field = value
         }
 

--- a/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/Inductor.kt
+++ b/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/Inductor.kt
@@ -5,9 +5,9 @@ package org.eln2.sim.electrical.mna.component
  *
  * Inductors are defined by a characteristic of "self-inductance", wherein magnetic flux (change in magnetic field) induces an electric field, quantified as magnetic flux per unit of current. Since induced voltage is proportional to magnetic flux, we can take the derivative of current with respect to time and determine instantaneous voltage.
  *
- * Of the two out-of-phase values that could be stored (the derivative of current, or the magnetic flux), this implementation uses the magnetic flux.
+ * Of the two out-of-phase values that could be stored (the derivative of current, or the magnetic flux), this implementation uses the magnetic flux [phi].
  *
- * This reactive component is simulated using a Norton system, as designed by Falstad. It is not "non-linear", however, and does not need any substeps to compute. It does, however, need to know the timescale of the simulation steps.
+ * This reactive component is simulated using a Norton system, as designed by Falstad. It is not "non-linear", however, and does not need any substeps to compute. It does, however, need to know the timescale of the simulation steps. Changing the simulation timestep dynamically can cause performance problems, however, and is best avoided.
  */
 open class Inductor : Port() {
     override var name: String = "l"
@@ -16,6 +16,11 @@ open class Inductor : Port() {
      * Self-inductance in Henries, singular Henry (Volts / Ampere).
      */
     var inductance: Double = 0.0
+        set(value) {
+            if(isInCircuit) unstamp()
+            field = value
+            if(isInCircuit) stamp()
+        }
 
     /**
      * The simulation timestep in seconds.
@@ -23,6 +28,11 @@ open class Inductor : Port() {
      * This is set in [preStep], but the value is unfortunately not available during [stamp]; thus, it may be slightly out of date when [step] is actually called.
      */
     var ts: Double = 0.05 // A safe default
+        set(value) {
+            if(isInCircuit) unstamp()
+            field = value
+            if(isInCircuit) stamp()
+        }
 
     /**
      * The "equivalent resistance" of the Norton system, in Ohms.
@@ -66,7 +76,7 @@ open class Inductor : Port() {
     }
 
     override fun preStep(dt: Double) {
-        ts = dt
+        if(ts != dt) ts = dt  // May cause a matrix solve--avoid this if possible
         i = phi / inductance
     }
 
@@ -76,5 +86,9 @@ open class Inductor : Port() {
 
     override fun stamp() { 
         pos!!.stampResistor(neg!!, eqR)
+    }
+
+    protected fun unstamp() {
+        if(pos != null && neg != null) pos!!.stampResistor(neg!!, -eqR)
     }
 }

--- a/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/Inductor.kt
+++ b/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/Inductor.kt
@@ -35,8 +35,8 @@ open class Inductor : Port() {
      */
     internal var i: Double = 0.0
         set(value) {
-            if (isInCircuit)
-                circuit!!.stampCurrentSource(pos.index, neg.index, value - field)
+            if (isInCircuit && pos != null && neg != null)
+                circuit!!.stampCurrentSource(pos!!.index, neg!!.index, value - field)
             field = value
         }
 
@@ -74,7 +74,7 @@ open class Inductor : Port() {
         phi += potential * ts
     }
 
-    override fun stamp() {
-        node(0).stampResistor(node(1), eqR)
+    override fun stamp() { 
+        pos!!.stampResistor(neg!!, eqR)
     }
 }

--- a/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/Resistor.kt
+++ b/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/Resistor.kt
@@ -1,5 +1,6 @@
 package org.eln2.sim.electrical.mna.component
 
+import org.eln2.debug.dprintln
 import org.eln2.sim.electrical.mna.Circuit
 
 /**
@@ -18,13 +19,15 @@ open class Resistor : Port() {
      */
     open var resistance: Double = 1.0
         set(value) {
-            // Remove our contribution to the matrix (using a negative resistance... should work)
-            field = -field
-            stamp()
+            if(isInCircuit) {
+                // Remove our contribution to the matrix (using a negative resistance... should work)
+                field = -field
+                stamp()
+            }
 
             // Add our new contribution
             field = value
-            stamp()
+            if(isInCircuit) stamp()
         }
 
     /**
@@ -44,7 +47,8 @@ open class Resistor : Port() {
     }
 
     override fun stamp() {
-        if (!isInCircuit) return
-        node(0).stampResistor(node(1), resistance)
+        dprintln("R.s: pos=$pos neg=$neg r=$resistance")
+        // We have to guard here specifically against stamp() being called out of context from the resistance setter above.
+        if(pos != null && neg != null) pos!!.stampResistor(neg!!, resistance)
     }
 }

--- a/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/VoltageSource.kt
+++ b/core/src/main/kotlin/org/eln2/sim/electrical/mna/component/VoltageSource.kt
@@ -35,6 +35,6 @@ class VoltageSource : Port() {
 
     override fun stamp() {
         if (!isInCircuit) return
-        vsources[0].stamp(pos, neg, potential)
+        vsources[0].stamp(pos!!, neg!!, potential)
     }
 }

--- a/core/src/test/kotlin/org/eln2/sim/electrical/mna/CircuitTest.kt
+++ b/core/src/test/kotlin/org/eln2/sim/electrical/mna/CircuitTest.kt
@@ -198,15 +198,15 @@ internal class CircuitTest {
 
         print("main_1: matrix:\n${MATRIX_FORMAT.format(c.matrix)}")
 
-        for (comp in c.components) {
+        c.components.forEach { comp ->
             println("main_1: comp $comp name ${comp.name} pins ${comp.pins} vs ${comp.vsources}")
-            for (pin in comp.pins) {
+            comp.pins.forEach { pin ->
                 val node = pin.node
                 println("\t node $node index ${node?.index} ground ${node?.isGround} potential ${node?.potential}")
             }
         }
 
-        for (node in c.nodes) {
+        c.nodes.forEach { node ->
             println("main_1: node ${node.get()} index ${node.get()?.index} potential ${node.get()?.potential}")
         }
 

--- a/core/src/test/kotlin/org/eln2/sim/electrical/mna/CircuitTest.kt
+++ b/core/src/test/kotlin/org/eln2/sim/electrical/mna/CircuitTest.kt
@@ -19,11 +19,12 @@ internal class CircuitTest {
 
         init {
             c.add(vs, r1)
-            vs.neg.named("vneg")
-            vs.pos.named("vpos")
+            // TODO: figure out how to name nodes early again
+            // vs.neg.named("vneg")
+            // vs.pos.named("vpos")
             vs.connect(1, r1, 1)
             vs.connect(0, r1, 0)
-            vs.connect(1, c.ground)
+            vs.ground(1)
             vs.potential = 10.0
             r1.resistance = 5.0
         }
@@ -37,15 +38,16 @@ internal class CircuitTest {
 
         init {
             c.add(vs, r1, c1)
-            vs.neg.named("vneg")
-            vs.pos.named("vpos")
+            // TODO: idem
+            // vs.neg.named("vneg")
+            // vs.pos.named("vpos")
             vs.potential = 10.0
             r1.resistance = 5.0
             c1.capacitance = 0.01
             vs.connect(0, r1, 0)
             c1.connect(0, r1, 0)
             vs.connect(1, c1, 1)
-            vs.connect(1, c.ground)
+            vs.ground(1)
         }
     }
 
@@ -54,7 +56,7 @@ internal class CircuitTest {
         val ts = TrivialResistiveCircuit()
         for (u in -1..1) {
             ts.vs.potential = u.toDouble()
-            ts.c.step(0.5)
+            assert(ts.c.step(0.5))
             assertEquals(sign(ts.vs.potential), sign(ts.r1.current))
         }
     }
@@ -64,7 +66,7 @@ internal class CircuitTest {
         val ts = TrivialResistiveCircuit()
         for (r in 1..10) {
             ts.r1.resistance = r.toDouble()
-            ts.c.step(0.5)
+            assert(ts.c.step(0.5))
             assertEquals(ts.r1.current, ts.vs.potential / r, EPSILON)
         }
     }
@@ -75,7 +77,7 @@ internal class CircuitTest {
         val ts = TrivialResistiveCircuit()
         for (r in 1..10) {
             ts.r1.resistance = r.toDouble()
-            ts.c.step(0.5)
+            assert(ts.c.step(0.5))
             try {
                 assertEquals(-ts.vs.current, ts.r1.current, EPSILON) { "r:${ts.r1.resistance} u:${ts.vs.potential}" }
             } catch (e: AssertionFailedError) {
@@ -89,7 +91,7 @@ internal class CircuitTest {
         val ts = TrivialResistiveCircuit()
         for (r in 1..10) {
             ts.r1.resistance = r.toDouble()
-            ts.c.step(0.5)
+            assert(ts.c.step(0.5))
             assertEquals(ts.vs.potential, ts.r1.potential, EPSILON)
         }
     }
@@ -106,14 +108,14 @@ internal class CircuitTest {
         r2.connect(0, ts.r1, 0)
         r2.connect(1, ts.r1, 1)
 
-        ts.c.step(0.5)
+        assert(ts.c.step(0.5))
         assertEquals(r2.current, ts.r1.current, EPSILON)
         assertEquals(ts.r1.current, current, EPSILON) { "i1_1=${ts.r1.current} i1_0=$current i2=${r2.current}" }
         assertEquals(ts.vs.current, current * 2.0, EPSILON)
 
         ts.c.remove(r2)
 
-        ts.c.step(0.5)
+        assert(ts.c.step(0.5))
         assertEquals(ts.r1.current, current, EPSILON)
         assertEquals(r2.circuit, null)
     }
@@ -133,9 +135,9 @@ internal class CircuitTest {
         vs.connect(1, r1, 1)
         r1.connect(0, r2, 1)
         r2.connect(0, vs, 0)
-        vs.connect(1, circuit.ground)
+        vs.ground(1)
 
-        circuit.step(0.5)
+        assert(circuit.step(0.5))
         assertEquals(r1.current, r2.current, EPSILON)
         assertEquals(r1.current, 1.0, EPSILON)
     }
@@ -152,24 +154,24 @@ internal class CircuitTest {
         circuit.add(vs, c1)
         vs.connect(1, c1, 1)
         vs.connect(0, c1, 0)
-        vs.connect(1, circuit.ground)
+        vs.ground(1)
 
-        circuit.step(0.5)
-        circuit.step(0.5)
-        circuit.step(0.5)
-        circuit.step(0.5)
+        assert(circuit.step(0.5))
+        assert(circuit.step(0.5))
+        assert(circuit.step(0.5))
+        assert(circuit.step(0.5))
     }
 
     //@Test
     fun basicRCCircuit() {
         val ts = TrivialRCCircuit()
-        ts.c.step(0.05)
+        assert(ts.c.step(0.05))
         assertEquals(ts.c1.current, 0.000732, 0.000001)
         assertEquals(ts.c1.potential, 6.315, 0.001)
-        ts.c.step(0.05)
+        assert(ts.c.step(0.05))
         assertEquals(ts.c1.current, 0.000270, 0.000001)
         assertEquals(ts.c1.potential, 8.660, 0.001)
-        ts.c.step(0.05)
+        assert(ts.c.step(0.05))
         assertEquals(ts.c1.current, 0.000099, 0.000001)
         assertEquals(ts.c1.potential, 9.506, 0.001)
     }
@@ -187,19 +189,20 @@ internal class CircuitTest {
 
         vs.connect(1, r1, 0)
         vs.connect(0, r1, 1)
-        vs.connect(1, c.ground)
+        vs.ground(1)
 
         vs.potential = 10.0
         r1.resistance = 100.0
 
-        c.step(0.5)
+        assert(c.step(0.5))
 
         print("main_1: matrix:\n${MATRIX_FORMAT.format(c.matrix)}")
 
         for (comp in c.components) {
-            println("main_1: comp $comp name ${comp.name} nodes ${comp.nodes} vs ${comp.vsources}")
-            for (node in comp.nodes) {
-                println("\t node $node index ${node.index} ground ${node.isGround} potential ${node.potential}")
+            println("main_1: comp $comp name ${comp.name} pins ${comp.pins} vs ${comp.vsources}")
+            for (pin in comp.pins) {
+                val node = pin.node
+                println("\t node $node index ${node?.index} ground ${node?.isGround} potential ${node?.potential}")
             }
         }
 

--- a/core/src/test/kotlin/org/eln2/sim/electrical/mna/CircuitTest.kt
+++ b/core/src/test/kotlin/org/eln2/sim/electrical/mna/CircuitTest.kt
@@ -166,13 +166,13 @@ internal class CircuitTest {
     fun basicRCCircuit() {
         val ts = TrivialRCCircuit()
         assert(ts.c.step(0.05))
-        assertEquals(ts.c1.current, 0.000732, 0.000001)
+        assertEquals(ts.c1.i, 0.000732, 0.000001)
         assertEquals(ts.c1.potential, 6.315, 0.001)
         assert(ts.c.step(0.05))
-        assertEquals(ts.c1.current, 0.000270, 0.000001)
+        assertEquals(ts.c1.i, 0.000270, 0.000001)
         assertEquals(ts.c1.potential, 8.660, 0.001)
         assert(ts.c.step(0.05))
-        assertEquals(ts.c1.current, 0.000099, 0.000001)
+        assertEquals(ts.c1.i, 0.000099, 0.000001)
         assertEquals(ts.c1.potential, 9.506, 0.001)
     }
 

--- a/core/src/test/kotlin/org/eln2/sim/electrical/mna/MNATests.kt
+++ b/core/src/test/kotlin/org/eln2/sim/electrical/mna/MNATests.kt
@@ -18,12 +18,12 @@ class MNATests {
 
         vs.connect(0, r, 0)
         vs.connect(1, r, 1)
-        vs.connect(0, c.ground)
+        vs.ground(0)
 
         vs.potential = 10.0
         r.resistance = 10.0
 
-        c.step(0.05)
+        assert(c.step(0.05))
         mnaPrint(c)
         assertEquals(true, (r.current > 0.99) and (r.current < 1.01))
     }
@@ -38,18 +38,18 @@ class MNATests {
 
         vs.connect(0, r, 0)
         vs.connect(1, r, 1)
-        vs.connect(0, c.ground)
+        vs.ground(0)
 
         vs.potential = 10.0
         r.resistance = 10.0
 
-        c.step(0.05)
+        assert(c.step(0.05))
         mnaPrint(c)
         assertEquals(true, (r.current > 0.99) and (r.current < 1.01))
 
         r.resistance = 50.0
 
-        c.step(0.05)
+        assert(c.step(0.05))
 
         mnaPrint(c)
         assertEquals(true, (r.current > 0.19) and (r.current < 0.21))
@@ -67,28 +67,28 @@ class MNATests {
         vs.connect(0, r1, 0)
         r1.connect(1, r2, 0)
         vs.connect(1, r2, 1)
-        vs.connect(0, c.ground)
+        vs.ground(0)
 
         vs.potential = 10.0
         r1.resistance = 10.0
         r2.resistance = 20.0
 
-        c.step(0.05)
+        assert(c.step(0.05))
         mnaPrint(c)
         assertEquals(true, (r1.current > 0.333) and (r1.current < 0.334))
         assertEquals(true, (r2.current > 0.333) and (r2.current < 0.334))
-        println(vs.nodes)
-        println(r1.nodes)
-        println(r2.nodes)
-        assertEquals(true, (r1.nodes[1].potential > 3.333) and (r1.nodes[1].potential < 3.334))
+        println(vs.pins)
+        println(r1.pins)
+        println(r2.pins)
+        assertEquals(true, ((r1.node(1)?.potential ?: 0.0) > 3.333) and ((r1.node(1)?.potential ?: 0.0) < 3.334))
 
         r2.resistance = 50.0
 
-        c.step(0.05)
+        assert(c.step(0.05))
 
         mnaPrint(c)
         assertEquals(true, (r1.current > 0.1666) and (r1.current < 0.1667))
         assertEquals(true, (r2.current > 0.1666) and (r2.current < 0.1667))
-        assertEquals(true, (r1.nodes[1].potential > 1.666) and (r1.nodes[1].potential < 1.667))
+        assertEquals(true, ((r1.node(1)?.potential ?: 0.0)> 1.666) and ((r1.node(1)?.potential ?: 0.0) < 1.667))
     }
 }

--- a/core/src/test/kotlin/org/eln2/sim/electrical/mna/MNATests.kt
+++ b/core/src/test/kotlin/org/eln2/sim/electrical/mna/MNATests.kt
@@ -1,6 +1,6 @@
 package org.eln2.sim.electrical.mna
 
-import org.eln2.debug.mnaPrint
+import org.eln2.debug.mnaPrintln
 import org.eln2.sim.electrical.mna.component.Resistor
 import org.eln2.sim.electrical.mna.component.VoltageSource
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -24,7 +24,7 @@ class MNATests {
         r.resistance = 10.0
 
         assert(c.step(0.05))
-        mnaPrint(c)
+        mnaPrintln(c)
         assertEquals(true, (r.current > 0.99) and (r.current < 1.01))
     }
 
@@ -44,14 +44,14 @@ class MNATests {
         r.resistance = 10.0
 
         assert(c.step(0.05))
-        mnaPrint(c)
+        mnaPrintln(c)
         assertEquals(true, (r.current > 0.99) and (r.current < 1.01))
 
         r.resistance = 50.0
 
         assert(c.step(0.05))
 
-        mnaPrint(c)
+        mnaPrintln(c)
         assertEquals(true, (r.current > 0.19) and (r.current < 0.21))
     }
 
@@ -74,7 +74,7 @@ class MNATests {
         r2.resistance = 20.0
 
         assert(c.step(0.05))
-        mnaPrint(c)
+        mnaPrintln(c)
         assertEquals(true, (r1.current > 0.333) and (r1.current < 0.334))
         assertEquals(true, (r2.current > 0.333) and (r2.current < 0.334))
         println(vs.pins)
@@ -86,7 +86,7 @@ class MNATests {
 
         assert(c.step(0.05))
 
-        mnaPrint(c)
+        mnaPrintln(c)
         assertEquals(true, (r1.current > 0.1666) and (r1.current < 0.1667))
         assertEquals(true, (r2.current > 0.1666) and (r2.current < 0.1667))
         assertEquals(true, ((r1.node(1)?.potential ?: 0.0)> 1.666) and ((r1.node(1)?.potential ?: 0.0) < 1.667))


### PR DESCRIPTION
This commit separates the logic of connection from the nodes used in
nodal analysis. The combination of the two was a byproduct of an older
API and causing misconceptions in the correct usage; errant usages are
much easier to obviate. As a result, connection to ground is now
special-cased.