### PR TITLE
Various Cleanup

### DIFF
--- a/src/main/java/org/eln2/mc/client/gui/PlotterScreen.kt
+++ b/src/main/java/org/eln2/mc/client/gui/PlotterScreen.kt
@@ -9,7 +9,6 @@ import net.minecraft.core.BlockPos
 import net.minecraft.network.FriendlyByteBuf
 import net.minecraft.network.chat.TextComponent
 import net.minecraft.resources.ResourceLocation
-import org.apache.logging.log4j.LogManager
 import org.eln2.mc.Eln2
 import org.eln2.mc.common.cell.CellRegistry
 import org.eln2.mc.extensions.ByteBufferExtensions.readString
@@ -143,7 +142,7 @@ class PlotterScreen(private val cells : ArrayList<CellInfo>) : Screen(TextCompon
     }
 
     override fun keyPressed(pKeyCode: Int, pScanCode: Int, pModifiers: Int): Boolean {
-        LogManager.getLogger().info("keycode: $blueprintTex scan: $pScanCode mod: $pModifiers")
+        Eln2.LOGGER.info("keycode: $blueprintTex scan: $pScanCode mod: $pModifiers")
 
         return super.keyPressed(pKeyCode, pScanCode, pModifiers)
     }

--- a/src/main/java/org/eln2/mc/client/input/Input.kt
+++ b/src/main/java/org/eln2/mc/client/input/Input.kt
@@ -11,7 +11,6 @@ import net.minecraftforge.client.event.InputEvent
 import net.minecraftforge.client.settings.KeyConflictContext
 import net.minecraftforge.eventbus.api.SubscribeEvent
 import net.minecraftforge.fml.common.Mod
-import org.eln2.mc.Eln2
 import org.eln2.mc.common.Networking
 import org.eln2.mc.common.blocks.CellBlockBase
 import org.eln2.mc.common.packets.clientToServer.CircuitExplorerOpenPacket
@@ -32,35 +31,21 @@ object Input {
 
     @SubscribeEvent
     fun inputEvent(event: InputEvent.KeyInputEvent){
-        if(OPEN_CIRCUIT_PLOTTER.isDown && event.action == GLFW.GLFW_PRESS){
-            Eln2.LOGGER.info("handle!")
+        if(OPEN_CIRCUIT_PLOTTER.isDown && event.action == GLFW.GLFW_PRESS)
             handleOpenCircuitPlotter()
-        }
-        else
-        {
-            Eln2.LOGGER.info("no, is down: ${OPEN_CIRCUIT_PLOTTER.isDown} action: ${event.action}")
-        }
     }
 
     private fun handleOpenCircuitPlotter(){
         val player = Minecraft.getInstance().cameraEntity as LivingEntity
-
         val pickResult = player.pick(100.0, 0f, false)
 
-        if(pickResult.type != HitResult.Type.BLOCK){
-            Eln2.LOGGER.info("did not hit")
+        if(pickResult.type != HitResult.Type.BLOCK)
             return
-        }
 
         val blockHit = pickResult as BlockHitResult
-        if(player.level.getBlockState(blockHit.blockPos).block !is CellBlockBase){
-            Eln2.LOGGER.info("it is not the block we're looking for")
+        if(player.level.getBlockState(blockHit.blockPos).block !is CellBlockBase)
             return
-        }
 
         Networking.sendToServer(CircuitExplorerOpenPacket())
-
-        //val cells = ArrayList(graph.cells.map { CellInfo(it.id.toString(), "n/a", it.pos) })
-
     }
 }

--- a/src/main/java/org/eln2/mc/client/input/Input.kt
+++ b/src/main/java/org/eln2/mc/client/input/Input.kt
@@ -11,7 +11,7 @@ import net.minecraftforge.client.event.InputEvent
 import net.minecraftforge.client.settings.KeyConflictContext
 import net.minecraftforge.eventbus.api.SubscribeEvent
 import net.minecraftforge.fml.common.Mod
-import org.apache.logging.log4j.LogManager
+import org.eln2.mc.Eln2
 import org.eln2.mc.common.Networking
 import org.eln2.mc.common.blocks.CellBlockBase
 import org.eln2.mc.common.packets.clientToServer.CircuitExplorerOpenPacket
@@ -33,12 +33,12 @@ object Input {
     @SubscribeEvent
     fun inputEvent(event: InputEvent.KeyInputEvent){
         if(OPEN_CIRCUIT_PLOTTER.isDown && event.action == GLFW.GLFW_PRESS){
-            LogManager.getLogger().info("handle!")
+            Eln2.LOGGER.info("handle!")
             handleOpenCircuitPlotter()
         }
         else
         {
-            LogManager.getLogger().info("no, is down: ${OPEN_CIRCUIT_PLOTTER.isDown} action: ${event.action}")
+            Eln2.LOGGER.info("no, is down: ${OPEN_CIRCUIT_PLOTTER.isDown} action: ${event.action}")
         }
     }
 
@@ -48,13 +48,13 @@ object Input {
         val pickResult = player.pick(100.0, 0f, false)
 
         if(pickResult.type != HitResult.Type.BLOCK){
-            LogManager.getLogger().info("did not hit")
+            Eln2.LOGGER.info("did not hit")
             return
         }
 
         val blockHit = pickResult as BlockHitResult
         if(player.level.getBlockState(blockHit.blockPos).block !is CellBlockBase){
-            LogManager.getLogger().info("it is not the block we're looking for")
+            Eln2.LOGGER.info("it is not the block we're looking for")
             return
         }
 

--- a/src/main/java/org/eln2/mc/common/In.kt
+++ b/src/main/java/org/eln2/mc/common/In.kt
@@ -1,3 +1,5 @@
+@file:Suppress("unused") // Specifier doesn't have any actual code use cases currently
+
 package org.eln2.mc.common
 
 enum class Side {

--- a/src/main/java/org/eln2/mc/common/Networking.kt
+++ b/src/main/java/org/eln2/mc/common/Networking.kt
@@ -13,6 +13,11 @@ import org.eln2.mc.common.packets.serverToClient.CircuitExplorerContextPacket
 typealias CEOPacket = CircuitExplorerOpenPacket
 typealias CECPacket = CircuitExplorerContextPacket
 
+enum class PacketType(val id: Int) {
+    CIRCUIT_EXPLORER_OPEN_PACKET(0),
+    CIRCUIT_EXPLORER_CONTEXT_PACKET(1)
+}
+
 object Networking {
     private const val protocolVersion = "1"
     private const val channelName = "main"
@@ -24,10 +29,8 @@ object Networking {
 
 
     fun setup(){
-        var id = -1
-
-        channel.registerMessage(++id, CEOPacket::class.java, CEOPacket::encode, ::CEOPacket, CEOPacket::handle)
-        channel.registerMessage(++id, CECPacket::class.java, CECPacket::encode, ::CECPacket, CECPacket::handle)
+        channel.registerMessage(PacketType.CIRCUIT_EXPLORER_OPEN_PACKET.id, CEOPacket::class.java, CEOPacket::encode, ::CEOPacket, CEOPacket::handle)
+        channel.registerMessage(PacketType.CIRCUIT_EXPLORER_CONTEXT_PACKET.id, CECPacket::class.java, CECPacket::encode, ::CECPacket, CECPacket::handle)
     }
 
     /**

--- a/src/main/java/org/eln2/mc/common/blocks/BlockRegistry.kt
+++ b/src/main/java/org/eln2/mc/common/blocks/BlockRegistry.kt
@@ -1,15 +1,14 @@
+@file:Suppress("unused") // Because block variables here would be suggested for deletion.
+
 package org.eln2.mc.common.blocks
 
 import net.minecraft.world.item.BlockItem
 import net.minecraft.world.item.Item
-import net.minecraft.world.level.block.Block
 import net.minecraft.world.level.block.entity.BlockEntityType
 import net.minecraftforge.eventbus.api.IEventBus
 import net.minecraftforge.registries.DeferredRegister
 import net.minecraftforge.registries.ForgeRegistries
 import net.minecraftforge.registries.RegistryObject
-import org.apache.logging.log4j.LogManager
-import org.apache.logging.log4j.Logger
 import org.eln2.mc.Eln2
 import org.eln2.mc.common.blocks.cell.GroundCellBlock
 import org.eln2.mc.common.blocks.cell.ResistorCellBlock
@@ -17,8 +16,6 @@ import org.eln2.mc.common.blocks.cell.VoltageSourceCellBlock
 import org.eln2.mc.common.blocks.cell.WireCellBlock
 
 object BlockRegistry {
-    private val LOGGER : Logger = LogManager.getLogger()
-
     private val BLOCK_REGISTRY = DeferredRegister.create(ForgeRegistries.BLOCKS, Eln2.MODID)
     private val BLOCK_ITEM_REGISTRY = DeferredRegister.create(ForgeRegistries.ITEMS, Eln2.MODID)
     private val BLOCK_ENTITY_REGISTRY = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITIES, Eln2.MODID)
@@ -27,7 +24,7 @@ object BlockRegistry {
         BLOCK_REGISTRY.register(bus)
         BLOCK_ITEM_REGISTRY.register(bus)
         BLOCK_ENTITY_REGISTRY.register(bus)
-        LOGGER.info("Prepared block, block item and block entity registry.")
+        Eln2.LOGGER.info("Prepared block, block item and block entity registry.")
     }
 
     val CELL_BLOCK_ENTITY: RegistryObject<BlockEntityType<CellTileEntity>> = BLOCK_ENTITY_REGISTRY.register("cell"){

--- a/src/main/java/org/eln2/mc/common/blocks/BlockRegistry.kt
+++ b/src/main/java/org/eln2/mc/common/blocks/BlockRegistry.kt
@@ -24,7 +24,6 @@ object BlockRegistry {
         BLOCK_REGISTRY.register(bus)
         BLOCK_ITEM_REGISTRY.register(bus)
         BLOCK_ENTITY_REGISTRY.register(bus)
-        Eln2.LOGGER.info("Prepared block, block item and block entity registry.")
     }
 
     val CELL_BLOCK_ENTITY: RegistryObject<BlockEntityType<CellTileEntity>> = BLOCK_ENTITY_REGISTRY.register("cell"){

--- a/src/main/java/org/eln2/mc/common/blocks/CellBlockBase.kt
+++ b/src/main/java/org/eln2/mc/common/blocks/CellBlockBase.kt
@@ -24,6 +24,7 @@ import org.eln2.mc.common.cell.CellRegistry
 
 abstract class CellBlockBase : HorizontalDirectionalBlock(Properties.of(Material.STONE)), EntityBlock {
     init {
+        @Suppress("LeakingThis")
         registerDefaultState(getStateDefinition().any().setValue(FACING, Direction.NORTH))
     }
 

--- a/src/main/java/org/eln2/mc/common/blocks/CellTileEntity.kt
+++ b/src/main/java/org/eln2/mc/common/blocks/CellTileEntity.kt
@@ -32,6 +32,7 @@ class CellTileEntity(var pos : BlockPos, var state: BlockState): BlockEntity(Blo
      * We use this to invalidate the adjacency cache. Next time we use it, we will query the world for the changes.
      * @see adjacentUpdateRequired
     */
+    @Suppress("UNUSED_PARAMETER") // Will very likely be needed later and helps to know the name of the args.
     @In(Side.LogicalServer)
     fun neighbourUpdated(pos : BlockPos) {
         adjacentUpdateRequired = true
@@ -43,6 +44,7 @@ class CellTileEntity(var pos : BlockPos, var state: BlockState): BlockEntity(Blo
      * It will add our cell to an existing circuit, or join multiple existing circuits, or create a new one
      * with ourselves.
     */
+    @Suppress("UNUSED_PARAMETER") // Will very likely be needed later and helps to know the name of the args.
     @In(Side.LogicalServer)
     fun setPlacedBy(
         level : Level,
@@ -218,6 +220,7 @@ class CellTileEntity(var pos : BlockPos, var state: BlockState): BlockEntity(Blo
      * Will set our cell's connections to the neighbours but exclude the provided cell.
      * @param exclude The cell to exclude.
     */
+    // TODO: Do we want this still?
     @In(Side.LogicalServer)
     private fun setCellConnectionsToAdjacentButExclude(exclude : CellBase){
         val adjacent = getAdjacentCellsFast()
@@ -318,6 +321,7 @@ class CellTileEntity(var pos : BlockPos, var state: BlockState): BlockEntity(Blo
      * Will get the direction of adjacent cells to us. Warning! this does not use a caching mechanism, it will query the world.
      * @return The directions where adjacent cells are located.
     */
+    // TODO: Do we want this still?
     @In(Side.LogicalServer)
     fun getAdjacentSides() : LinkedList<Direction>  {
         val result = LinkedList<Direction>()
@@ -405,6 +409,7 @@ class CellTileEntity(var pos : BlockPos, var state: BlockState): BlockEntity(Blo
      * @param dir The direction towards entity.
      * @return True if the connection is accepted.
     */
+    @Suppress("UNUSED_PARAMETER") // Will very likely be needed later and helps to know the name of the args.
     @In(Side.LogicalServer)
     private fun canConnectFrom(entity : CellTileEntity, dir : Direction) : Boolean {
         return connectPredicate(dir.opposite)

--- a/src/main/java/org/eln2/mc/common/blocks/CellTileEntity.kt
+++ b/src/main/java/org/eln2/mc/common/blocks/CellTileEntity.kt
@@ -103,7 +103,6 @@ class CellTileEntity(var pos : BlockPos, var state: BlockState): BlockEntity(Blo
         if(adjacentTiles.isEmpty()){
            // we are alone
             cell.graph.destroyAndRemove()
-            Eln2.LOGGER.info("Destroyed ourselves")
             return
         }
 

--- a/src/main/java/org/eln2/mc/common/cell/CellGraphManager.kt
+++ b/src/main/java/org/eln2/mc/common/cell/CellGraphManager.kt
@@ -15,6 +15,7 @@ import java.util.*
 class CellGraphManager(val level : Level) : SavedData() {
     private val graphs = HashMap<UUID, CellGraph>()
 
+    // TODO: Is this still useful?
     fun containsGraph(graph : CellGraph) : Boolean{
         return graphs.containsKey(graph.id)
     }

--- a/src/main/java/org/eln2/mc/common/cell/providers/TwoPinCellProvider.kt
+++ b/src/main/java/org/eln2/mc/common/cell/providers/TwoPinCellProvider.kt
@@ -1,7 +1,7 @@
 package org.eln2.mc.common.cell.providers
 
 import net.minecraft.core.BlockPos
-import org.apache.logging.log4j.LogManager
+import org.eln2.mc.Eln2
 import org.eln2.mc.common.RelativeRotationDirection
 import org.eln2.mc.common.cell.CellBase
 import org.eln2.mc.common.cell.CellProvider
@@ -19,7 +19,7 @@ class TwoPinCellProvider(val factory : ((pos : BlockPos) -> CellBase), override 
     }
 
     override fun connectionPredicate(dir: RelativeRotationDirection): Boolean {
-        LogManager.getLogger().info("DIR: $dir")
+        Eln2.LOGGER.info("DIR: $dir")
         return true
     }
 }

--- a/src/main/java/org/eln2/mc/common/packets/clientToServer/CircuitExplorerOpenPacket.kt
+++ b/src/main/java/org/eln2/mc/common/packets/clientToServer/CircuitExplorerOpenPacket.kt
@@ -5,7 +5,6 @@ import net.minecraft.server.level.ServerPlayer
 import net.minecraft.world.phys.BlockHitResult
 import net.minecraft.world.phys.HitResult
 import net.minecraftforge.network.NetworkEvent
-import org.apache.logging.log4j.LogManager
 import org.eln2.mc.Eln2
 import org.eln2.mc.client.gui.CellInfo
 import org.eln2.mc.common.Networking
@@ -17,7 +16,9 @@ class CircuitExplorerOpenPacket() {
     constructor(buffer : FriendlyByteBuf) : this() { }
 
     companion object{
+        @Suppress("UNUSED_PARAMETER") // This will be useful later
         fun encode(packet : CircuitExplorerOpenPacket, buffer : FriendlyByteBuf){ }
+        @Suppress("UNUSED_PARAMETER") // This will be useful later
         fun handle(packet : CircuitExplorerOpenPacket, supplier : Supplier<NetworkEvent.Context>){
             val context = supplier.get()
 
@@ -30,7 +31,7 @@ class CircuitExplorerOpenPacket() {
             val pickResult = player.pick(100.0, 0f, false)
 
             if(pickResult.type != HitResult.Type.BLOCK){
-                LogManager.getLogger().info("server did not hit")
+                Eln2.LOGGER.info("server did not hit")
                 return
             }
 
@@ -38,7 +39,7 @@ class CircuitExplorerOpenPacket() {
             val tile = player.level.getBlockEntity(blockHit.blockPos) as CellTileEntity?
 
             if(tile !is CellTileEntity){
-                Eln2.LOGGER.info("it is not the tile, it is $tile")
+                Eln2.LOGGER.info("it is not the tile, it is ${player.level.getBlockEntity(blockHit.blockPos)}")
                 return
             }
 


### PR DESCRIPTION
* Cleans up logger instances
    * I keep finding these; @empireu, you do realize that a log4j logger is thread safe and designed for it, right? Using one static logger instance is going to be a lot better than building new ones all the time.
> Log4j components are designed to be used in heavily multithreaded systems.
https://logging.apache.org/log4j/1.2/faq.html#a1.7
* Fixed a bug in Circuit Explorer Open Packet implementation (See L42)
* Set some linter overrrides for situations where they didn't help anything.
* Converted Networking packet registration to use an enum instead of an autoincremented digit to prevent issues in the future if packets are added out-of-order (id's are now static to the type in the enum declaration)