### PR TITLE
Adds configuration and statistics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,12 +11,14 @@ buildscript {
         classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '5.1.+', changing: true
         classpath 'org.parchmentmc:librarian:1.+'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
         classpath "gradle.plugin.com.github.johnrengelman:shadow:7.1.1"
     }
 }
 apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'org.parchmentmc.librarian.forgegradle'
 apply plugin: 'kotlin'
+apply plugin: 'kotlinx-serialization'
 apply plugin: "com.github.johnrengelman.shadow"
 apply from: 'https://raw.githubusercontent.com/thedarkcolour/KotlinForForge/site/thedarkcolour/kotlinforforge/gradle/kff-3.0.0.gradle'
 apply plugin: 'eclipse'
@@ -116,6 +118,8 @@ dependencies {
     runtimeOnly fg.deobf("mcp.mobius.waila:wthit:forge-4.5.1")
     library('com.github.age-series:libage:main-SNAPSHOT')
     library("org.apache.commons:commons-math3:3.6.1")
+    library("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.2")
+    library('com.charleskorn.kaml:kaml:0.40.0')
 
     // Real mod deobf dependency examples - these get remapped to your current mappings
     // compileOnly fg.deobf("mezz.jei:jei-${mc_version}:${jei_version}:api") // Adds JEI API as a compile dependency

--- a/src/main/java/org/eln2/mc/Eln2.kt
+++ b/src/main/java/org/eln2/mc/Eln2.kt
@@ -3,18 +3,25 @@ package org.eln2.mc
 import net.minecraftforge.fml.common.Mod
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
+import org.eln2.mc.common.Configuration
+import org.eln2.mc.common.ElectricalAgeConfiguration
 import org.eln2.mc.common.network.Networking
 import org.eln2.mc.common.blocks.BlockRegistry
 import org.eln2.mc.common.cell.CellRegistry
 import org.eln2.mc.common.items.ItemRegistry
+import org.eln2.mc.common.network.ModStatistics
 import thedarkcolour.kotlinforforge.forge.MOD_BUS
 
 @Mod(Eln2.MODID)
 object Eln2 {
     const val MODID = "eln2"
     val LOGGER: Logger = LogManager.getLogger()
+    val config: ElectricalAgeConfiguration
 
     init {
+        Configuration.loadConfig()
+        config = Configuration.config
+
         BlockRegistry.setup(MOD_BUS)
         ItemRegistry.setup(MOD_BUS)
 
@@ -24,5 +31,9 @@ object Eln2 {
         CellRegistry.setup(MOD_BUS)
 
         LOGGER.info("Prepared registries.")
+
+        if (config.enableAnalytics) {
+            ModStatistics.sendAnalytics()
+        }
     }
 }

--- a/src/main/java/org/eln2/mc/common/Configuration.kt
+++ b/src/main/java/org/eln2/mc/common/Configuration.kt
@@ -1,0 +1,54 @@
+package org.eln2.mc.common
+
+import com.charleskorn.kaml.Yaml
+import kotlinx.serialization.Serializable
+import org.eln2.mc.Eln2.LOGGER
+import java.io.File
+import java.util.*
+
+object Configuration {
+    private val CONFIG_FILE: File = File("config/electrical_age.yaml")
+    var config: ElectricalAgeConfiguration = ElectricalAgeConfiguration()
+
+    fun loadConfig(configFile: File = CONFIG_FILE) {
+        try {
+            if (configFile.isFile) {
+                LOGGER.info("[Electrical Age] Reading config from ${configFile.absoluteFile}")
+                config = Yaml.default.decodeFromStream(ElectricalAgeConfiguration.serializer(), configFile.inputStream())
+            } else {
+                config = ElectricalAgeConfiguration()
+                saveConfig()
+            }
+        } catch (e: Exception) {
+            LOGGER.error("Electrical Age had an issue with loading the configuration file, please check the file for errors.")
+            LOGGER.error("Check that 1) You have valid YAML 2) the config directives are spelled correctly (see documentation)")
+        }
+    }
+
+    private fun saveConfig(configFile: File = CONFIG_FILE) {
+        try {
+            LOGGER.info("[Electrical Age] Writing config to ${configFile.absoluteFile}")
+            val configText = Yaml.default.encodeToString(ElectricalAgeConfiguration.serializer(), config)
+            if (!configFile.exists()) {
+                configFile.createNewFile()
+            }
+            configFile.writeText(configText)
+        } catch (e: Exception) {
+            LOGGER.error("Electrical Age was unable to write the config file, please check filesystem permissions: $e")
+        }
+    }
+}
+
+/**
+ * ElectricalAgeConfiguration
+ *
+ * NOTE: ALL FIELDS _MUST_ have default values when called, since the user will likely want a sane default!
+ * They may be blank, but MUST be present. Thanks!
+ */
+@Serializable
+data class ElectricalAgeConfiguration (
+    var enableAnalytics: Boolean = true,
+    // TODO: Replace with stats.age-series.org (but needs CAA certificates)
+    var analyticsEndpoint: String = "https://ingz5drycg.execute-api.us-east-1.amazonaws.com/",
+    var analyticsUuid: String = UUID.randomUUID().toString()
+)

--- a/src/main/java/org/eln2/mc/common/network/ModStatistics.kt
+++ b/src/main/java/org/eln2/mc/common/network/ModStatistics.kt
@@ -1,0 +1,70 @@
+package org.eln2.mc.common.network
+
+import kotlinx.serialization.Serializable
+import org.apache.http.client.methods.HttpPost
+import org.apache.http.entity.StringEntity
+import org.apache.http.impl.client.HttpClientBuilder
+import org.eln2.mc.Eln2
+import org.eln2.mc.Eln2.LOGGER
+import java.util.*
+import kotlin.concurrent.thread
+
+object ModStatistics {
+    var sent = false
+
+    private fun collectData(): AnalyticsData {
+        try {
+            return AnalyticsData(
+                "",
+                "electrical_age",
+                "",
+                "",
+                Locale.getDefault().toLanguageTag()
+            )
+        } catch (e: Exception) {
+            LOGGER.warn("Tried to get analytics and failed :/")
+            error("Tried to get analytics and failed :/")
+        }
+    }
+
+    fun sendAnalytics() {
+        if (sent) { return }
+        thread (start = true, isDaemon = true, name = "Electrical Age Analytics") {
+            try {
+                val data = collectData()
+                val serialized = """
+                    {
+                       "uuid": "${data.uuid}",
+                       "mod_id": "${data.mod_id}",
+                       "avg_sim_performance": "${data.avg_sim_performance}",
+                       "game_lang": "${data.game_lang}",
+                       "os_lang": "${data.os_lang}"
+                    }
+                """.trimIndent()
+                LOGGER.debug("Sending HTTPS Post request to :\n$")
+                val httpClient = HttpClientBuilder.create().build()
+                val request = HttpPost(Eln2.config.analyticsEndpoint)
+                val params = StringEntity(serialized)
+                request.addHeader("content-type", "application/json")
+                request.entity = params
+                val resp = httpClient.execute(request)
+                if (resp.statusLine.statusCode != 200) {
+                    LOGGER.warn(resp)
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+                LOGGER.warn("Failed to send analytics information to server")
+            }
+        }
+        sent = true
+    }
+}
+
+@Serializable
+data class AnalyticsData(
+    var uuid: String = "",
+    var mod_id: String = "electrical_age",
+    var avg_sim_performance: String = "",
+    var game_lang: String = "",
+    var os_lang: String = Locale.getDefault().toLanguageTag()
+)


### PR DESCRIPTION
Adds:
* Configuration file - automatically makes configuration file if not generated already
* Analytics - sends analytics to analytics endpoint

The analytics are not completely implemented, someone can feel welcome to implement the following on top of it:
* Proper JSON serialization to the API (since the Json serializer is apparently broken)
* Send sim statistics at the end of the world (when saving)
* Send the actual client language (since I tried to and it crashes the game somehow)
* I'll need to fix my CAA records with the domain name registrar so that I can use the proper DNS name.

The code that I used to collect analytics will collect IP, uuid (unique per config, not the Mojang one), system language, and will later collect one or two other things. See the existing disclaimer for Eln1 for now because it's the same stuff really.

~The actual source code will be uploaded to a different repository. I don't currently have CDK for the API and made it by hand in my AWS account for this stuff.~ Done.