### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
 println('Java: ' + System.getProperty('java.version') + ' JVM: ' + System.getProperty('java.vm.version') + '(' + System.getProperty('java.vendor') + ') Arch: ' + System.getProperty('os.arch'))
 minecraft {
-    mappings channel: 'parchment', version: "2022.02.13-1.18.1"
+    mappings channel: 'parchment', version: "2022.03.13-1.18.2"
 
     accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'org.parchmentmc.librarian.forgegradle'
 apply plugin: 'kotlin'
 apply plugin: 'kotlinx-serialization'
 apply plugin: "com.github.johnrengelman.shadow"
-apply from: 'https://raw.githubusercontent.com/thedarkcolour/KotlinForForge/site/thedarkcolour/kotlinforforge/gradle/kff-3.0.0.gradle'
+apply from: 'https://raw.githubusercontent.com/thedarkcolour/KotlinForForge/site/thedarkcolour/kotlinforforge/gradle/kff-3.1.0.gradle'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
@@ -115,7 +115,6 @@ repositories {
 
 dependencies {
     minecraft 'net.minecraftforge:forge:1.18.2-40.0.4'
-    implementation 'thedarkcolour:kotlinforforge:3.1.0'
     compileOnly fg.deobf("mcp.mobius.waila:wthit-api:forge-4.7.2")
     runtimeOnly fg.deobf("mcp.mobius.waila:wthit:forge-4.7.2")
     library('com.github.age-series:libage:main-SNAPSHOT')


### PR DESCRIPTION
- Update Parchment mappings to 1.18.2 (closes #202)
- Only use KFF 3.1.0 instead of 3.0.0 & 3.1.0