### PR TITLE
Fix ClassDefNotFound in shaded jars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'org.parchmentmc.librarian.forgegradle'
 apply plugin: 'kotlin'
 apply plugin: 'kotlinx-serialization'
 apply plugin: "com.github.johnrengelman.shadow"
-apply from: 'https://raw.githubusercontent.com/thedarkcolour/KotlinForForge/site/thedarkcolour/kotlinforforge/gradle/kff-3.1.0.gradle'
+apply from: 'https://raw.githubusercontent.com/thedarkcolour/KotlinForForge/site/thedarkcolour/kotlinforforge/gradle/kff-3.3.2.gradle'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
@@ -35,7 +35,7 @@ java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
 println('Java: ' + System.getProperty('java.version') + ' JVM: ' + System.getProperty('java.vm.version') + '(' + System.getProperty('java.vendor') + ') Arch: ' + System.getProperty('os.arch'))
 minecraft {
-    mappings channel: 'parchment', version: "2022.03.13-1.18.2"
+    mappings channel: 'parchment', version: "2022.05.22-1.18.2"
 
     accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
 
@@ -88,7 +88,6 @@ minecraft {
 configurations {
     library
     implementation.extendsFrom library
-    shadow.extendsFrom library
 }
 
 minecraft.runs.all {
@@ -114,7 +113,7 @@ repositories {
 }
 
 dependencies {
-    minecraft 'net.minecraftforge:forge:1.18.2-40.0.4'
+    minecraft 'net.minecraftforge:forge:1.18.2-40.1.25'
     compileOnly fg.deobf("mcp.mobius.waila:wthit-api:forge-4.7.2")
     runtimeOnly fg.deobf("mcp.mobius.waila:wthit:forge-4.7.2")
     library('com.github.age-series:libage:main-SNAPSHOT')
@@ -133,6 +132,7 @@ dependencies {
 
 jar {
     //noinspection GroovyAssignabilityCheck
+    archiveClassifier = 'slim'
     manifest {
         attributes([
                 "Specification-Title"     : "eln2",
@@ -154,10 +154,12 @@ jar {
 def shaded = [
     "com.charleskorn.kaml",
     "org.snakeyaml",
-    "org.apache.commons"
+    "org.apache.commons",
+    "com.github.age-series"
 ].stream().collect()
 
 shadowJar {
+    archiveClassifier = ''
     dependencies {
         exclude(dependency {
             def res = !shaded.contains(it.moduleGroup)
@@ -167,16 +169,17 @@ shadowJar {
         })
     }
     shaded.forEach {
-        relocate it, "org.ageseries.shadow" + it
+        relocate it, "org.ageseries.shadow." + it
     }
+
+    finalizedBy 'reobfShadowJar'
 }
+
+assemble.dependsOn shadowJar
 
 reobf {
     shadowJar { }
 }
-tasks.build.dependsOn reobfShadowJar
-jar.finalizedBy 'reobfShadowJar'
-shadowJar.finalizedBy 'reobfShadowJar'
 
 // This is the preferred method to reobfuscate your jar file
 jar.finalizedBy('reobfJar')

--- a/src/main/java/org/eln2/mc/common/cell/CellRegistry.kt
+++ b/src/main/java/org/eln2/mc/common/cell/CellRegistry.kt
@@ -1,26 +1,23 @@
 package org.eln2.mc.common.cell
 
 import net.minecraft.resources.ResourceLocation
-import net.minecraftforge.event.RegistryEvent
 import net.minecraftforge.eventbus.api.IEventBus
 import net.minecraftforge.eventbus.api.SubscribeEvent
 import net.minecraftforge.fml.common.Mod
-import net.minecraftforge.registries.DeferredRegister
-import net.minecraftforge.registries.IForgeRegistry
-import net.minecraftforge.registries.RegistryBuilder
-import net.minecraftforge.registries.RegistryObject
+import net.minecraftforge.registries.*
 import org.eln2.mc.Eln2
 import org.eln2.mc.Eln2.LOGGER
 import org.eln2.mc.common.cell.providers.FourPinCellProvider
 import org.eln2.mc.common.cell.providers.NoPinCellProvider
 import org.eln2.mc.common.cell.providers.TwoPinCellProvider
 import org.eln2.mc.common.cell.types.*
+import java.util.function.Supplier
 
 @Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD)
 object CellRegistry {
     private val CELLS = DeferredRegister.create(CellProvider::class.java, Eln2.MODID)
-    private var REGISTRY : IForgeRegistry<CellProvider>? = null
-    val registry get() = REGISTRY!!
+    private var REGISTRY : Supplier<IForgeRegistry<CellProvider>?>? = null
+    val registry get() = REGISTRY!!.get()!!
 
     val RESISTOR_CELL = register("resistor", TwoPinCellProvider { ResistorCell(it) })
     val WIRE_CELL = register("wire", FourPinCellProvider { WireCell(it) })
@@ -40,11 +37,11 @@ object CellRegistry {
     }
 
     @SubscribeEvent
-    fun createRegistry(event : RegistryEvent.NewRegistry) {
+    fun createRegistry(event : NewRegistryEvent) {
         val reg = RegistryBuilder<CellProvider>()
         reg.setName(ResourceLocation(Eln2.MODID, "cells"))
         reg.type = CellProvider::class.java
-        REGISTRY = reg.create()
+        REGISTRY = event.create(reg)
         LOGGER.info("Created cell registry!")
     }
 


### PR DESCRIPTION
The `shadowJar` target will now build a jar that will run in a non-development environment.