### PR TITLE
Diode orientation

### DIFF
--- a/src/main/java/org/eln2/mc/common/blocks/CellTileEntity.kt
+++ b/src/main/java/org/eln2/mc/common/blocks/CellTileEntity.kt
@@ -1,6 +1,5 @@
 package org.eln2.mc.common.blocks
 
-import mcp.mobius.waila.api.IServerDataProvider
 import net.minecraft.core.BlockPos
 import net.minecraft.core.Direction
 import net.minecraft.nbt.CompoundTag
@@ -56,7 +55,7 @@ class CellTileEntity(var pos : BlockPos, var state: BlockState): BlockEntity(Blo
             return
         }
 
-        println("Cell is created at $position")
+        Eln2.LOGGER.debug("Cell is created at $position")
         cell = cellProvider.create(position)
         cell!!.tile = this
         cell!!.id = cellProvider.registryName!!
@@ -394,15 +393,15 @@ class CellTileEntity(var pos : BlockPos, var state: BlockState): BlockEntity(Blo
     }
 
     /**
-     * Applies the connection predicate for that direction.
-     * @param entity The entity we are checking.
+     * Applies entity's connection predicate to the opposite of dir.
+     *
+     * Determines if *this* [CellTileEntity] can connect to [entity] by making a connection towards [dir]
+     * @param entity The entity we are connecting to.
      * @param dir The direction towards entity.
      * @return True if the connection is accepted.
     */
-    @Suppress("UNUSED_PARAMETER") // Will very likely be needed later and helps to know the name of the args.
     private fun canConnectFrom(entity : CellTileEntity, dir : Direction) : Boolean {
-        return connectPredicate(dir.opposite)
-
+        return entity.connectPredicate(dir.opposite)
     }
 
     override fun saveAdditional(pTag: CompoundTag) {

--- a/src/main/java/org/eln2/mc/common/blocks/CellTileEntity.kt
+++ b/src/main/java/org/eln2/mc/common/blocks/CellTileEntity.kt
@@ -12,6 +12,7 @@ import net.minecraft.world.level.block.entity.BlockEntity
 import net.minecraft.world.level.block.state.BlockState
 import org.eln2.mc.Eln2
 import org.eln2.mc.common.PlacementRotation
+import org.eln2.mc.common.RelativeRotationDirection
 import org.eln2.mc.common.cell.*
 import java.util.*
 import kotlin.system.measureNanoTime
@@ -390,6 +391,15 @@ class CellTileEntity(var pos : BlockPos, var state: BlockState): BlockEntity(Blo
         val remoteEnt = level.getBlockEntity(remotePos)
 
         return remoteEnt as CellTileEntity?
+    }
+
+    fun getFrontNeighbor() : CellTileEntity? {
+        val level = getLevel()!!
+        val frontDir = PlacementRotation(state.getValue(HorizontalDirectionalBlock.FACING))
+            .getAbsoluteFromRelative(RelativeRotationDirection.Front)
+        val remoteEnt = level.getBlockEntity(pos.relative(frontDir))
+
+        return remoteEnt as? CellTileEntity
     }
 
     /**

--- a/src/main/java/org/eln2/mc/common/cell/providers/TwoPinCellProvider.kt
+++ b/src/main/java/org/eln2/mc/common/cell/providers/TwoPinCellProvider.kt
@@ -20,6 +20,6 @@ class TwoPinCellProvider(val factory : ((pos : BlockPos) -> CellBase)) : CellPro
 
     override fun connectionPredicate(dir: RelativeRotationDirection): Boolean {
         Eln2.LOGGER.info("DIR: $dir")
-        return true
+        return connectableDirections.contains(dir)
     }
 }

--- a/src/main/java/org/eln2/mc/common/cell/types/DiodeCell.kt
+++ b/src/main/java/org/eln2/mc/common/cell/types/DiodeCell.kt
@@ -6,7 +6,6 @@ import org.eln2.mc.common.cell.CellBase
 import org.eln2.mc.common.cell.ComponentInfo
 import org.eln2.mc.extensions.ComponentExtensions.connectToPinOf
 import org.eln2.mc.utility.UnitType
-import org.eln2.mc.utility.ValueText
 import org.eln2.mc.utility.ValueText.valueText
 
 class DiodeCell(pos : BlockPos): CellBase(pos) {
@@ -24,7 +23,13 @@ class DiodeCell(pos : BlockPos): CellBase(pos) {
             circuit.add(diode)
             added = true
         }
-        return ComponentInfo(diode, connections.indexOf(neighbour))
+        //We must ensure the negative side is the "front" of the diode
+        //According to libage, it's an arbitrary convention that negative is node 0 and positive is node 1
+        return if (neighbour.tile == this.tile?.getFrontNeighbor()) {
+            ComponentInfo(diode, 0)
+        } else {
+            ComponentInfo(diode, 1)
+        }
     }
 
     override fun buildConnections() {


### PR DESCRIPTION
I'm 100% sure there's a much better way to do this. However I'm not really familiar with the simulator enough to figure something out there.

- TwoPinCells no longer return true for any direction in their predicate
- The negative pin of a diode is now always the "front" of the diode

I've had some bizarre issues with saving while working on this, sometimes connecting circuits that were saved in a previous run of the world caused some stuff in the TEs to fail to save with a bunch of NPEs. I'm not sure it's related, but we may want to go clean up all our `!!` uses in cell a bit.